### PR TITLE
feat(integrations): Bot Framework channel helper (Fix 3 of agent-hub#2)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-bot-framework-channel-helper.md
+++ b/docs/superpowers/plans/2026-04-28-bot-framework-channel-helper.md
@@ -1,0 +1,313 @@
+# Bot Framework Channel Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship `monkai_trace.integrations.bot_framework.infer_channel(payload)` as a reusable utility, with a parametrised test suite, exported from `monkai_trace.integrations`.
+
+**Architecture:** A single module file with one stateless function and a private mapping constant. Tests are table-driven with `pytest.mark.parametrize`. No runtime hooks, no IO.
+
+**Tech Stack:** Python 3.8+, pytest. Zero new runtime dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-28-bot-framework-channel-helper-design.md`
+
+---
+
+## File structure
+
+- Create: `monkai_trace/integrations/bot_framework.py`
+- Create: `tests/test_bot_framework_integration.py`
+- Modify: `monkai_trace/integrations/__init__.py` — re-export `infer_channel`
+
+---
+
+## Task 1: implement helper + tests + export
+
+**Files:**
+- Create: `monkai_trace/integrations/bot_framework.py`
+- Create: `tests/test_bot_framework_integration.py`
+- Modify: `monkai_trace/integrations/__init__.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_bot_framework_integration.py`:
+
+```python
+"""Tests for the Bot Framework channel inference helper."""
+
+import pytest
+from monkai_trace.integrations.bot_framework import infer_channel
+
+
+@pytest.mark.parametrize("channel_id, expected", [
+    ("msteams", "teams"),
+    ("directline", "web"),
+    ("webchat", "web"),
+    ("emulator", "emulator"),
+])
+def test_known_channel_ids_map_correctly(channel_id, expected):
+    assert infer_channel({"channelId": channel_id}) == expected
+
+
+@pytest.mark.parametrize("channel_id, expected", [
+    ("MSTEAMS", "teams"),
+    ("MsTeams", "teams"),
+    ("DirectLine", "web"),
+    ("WEBCHAT", "web"),
+])
+def test_known_channel_ids_are_case_insensitive(channel_id, expected):
+    assert infer_channel({"channelId": channel_id}) == expected
+
+
+@pytest.mark.parametrize("channel_id, expected", [
+    ("slack", "slack"),
+    ("Slack", "slack"),
+    ("custom-bot", "custom-bot"),
+])
+def test_unknown_channel_ids_pass_through_lowercased(channel_id, expected):
+    assert infer_channel({"channelId": channel_id}) == expected
+
+
+@pytest.mark.parametrize("payload", [
+    {},
+    {"channelId": None},
+    {"channelId": ""},
+])
+def test_missing_or_empty_channel_id_returns_unknown(payload):
+    assert infer_channel(payload) == "unknown"
+
+
+def test_other_payload_fields_are_ignored():
+    payload = {
+        "channelId": "msteams",
+        "from": {"id": "user-123", "aadObjectId": "aad-456"},
+        "type": "message",
+        "text": "hello",
+    }
+    assert infer_channel(payload) == "teams"
+
+
+def test_helper_is_exported_at_integrations_level():
+    """Verify the flat re-export from monkai_trace.integrations works."""
+    from monkai_trace.integrations import infer_channel as flat_export
+    assert flat_export({"channelId": "msteams"}) == "teams"
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+```bash
+cd ~/Desktop/Monkai/monkai-trace
+.venv/bin/pytest tests/test_bot_framework_integration.py -v --no-cov
+```
+
+Expected: import error — `monkai_trace.integrations.bot_framework` does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+Create `monkai_trace/integrations/bot_framework.py`:
+
+```python
+"""Bot Framework integration helpers for monkai-trace.
+
+Helps callers translate Microsoft Bot Framework activity payloads into the
+fields monkai-trace's upload_record expects. Currently scoped to channel
+inference; future helpers can land here as Bot Framework adoption grows.
+"""
+
+from typing import Mapping
+
+# Microsoft Bot Framework channelId → MonkAI channel string.
+# https://learn.microsoft.com/en-us/azure/bot-service/bot-service-channels-reference
+_CHANNEL_MAP: Mapping[str, str] = {
+    "msteams": "teams",
+    "directline": "web",
+    "webchat": "web",
+    "emulator": "emulator",
+}
+
+
+def infer_channel(payload: dict) -> str:
+    """Map a Bot Framework activity's `channelId` to a MonkAI channel string.
+
+    Unknown values pass through lower-cased so the dashboard surfaces them
+    for investigation rather than silently mislabelling. Missing or empty
+    channelId returns "unknown".
+
+    Args:
+        payload: A Bot Framework activity payload (from ``await req.json()``
+            in the webhook handler).
+
+    Returns:
+        The channel string suitable for ``MonkAIClient.upload_record``'s
+        ``external_user_channel`` argument.
+    """
+    raw = (payload.get("channelId") or "").lower()
+    return _CHANNEL_MAP.get(raw, raw or "unknown")
+```
+
+- [ ] **Step 4: Add the flat re-export**
+
+Modify `monkai_trace/integrations/__init__.py` from:
+
+```python
+"""Integrations for popular AI agent frameworks"""
+
+from .openai_agents import MonkAIRunHooks
+from .logging import MonkAILogHandler
+from .langchain import MonkAICallbackHandler
+from .monkai_agent import MonkAIAgentHooks
+
+__all__ = ["MonkAIRunHooks", "MonkAILogHandler", "MonkAICallbackHandler", "MonkAIAgentHooks"]
+```
+
+to:
+
+```python
+"""Integrations for popular AI agent frameworks"""
+
+from .openai_agents import MonkAIRunHooks
+from .logging import MonkAILogHandler
+from .langchain import MonkAICallbackHandler
+from .monkai_agent import MonkAIAgentHooks
+from .bot_framework import infer_channel
+
+__all__ = [
+    "MonkAIRunHooks",
+    "MonkAILogHandler",
+    "MonkAICallbackHandler",
+    "MonkAIAgentHooks",
+    "infer_channel",
+]
+```
+
+- [ ] **Step 5: Run tests until green**
+
+```bash
+.venv/bin/pytest tests/test_bot_framework_integration.py -v --no-cov
+```
+
+Expected: all parametrized cases pass — total 16 cases (4 known mappings + 4 case-insensitive + 3 passthrough + 3 missing/empty + 1 other-fields-ignored + 1 flat-export).
+
+- [ ] **Step 6: Run regression to ensure no other test broke**
+
+```bash
+.venv/bin/pytest tests/test_baseline_anonymizer.py tests/test_client_anonymization.py tests/test_client.py tests/test_models.py tests/test_session_manager.py tests/test_bot_framework_integration.py --no-cov
+```
+
+Expected: same baseline pass count from prior PRs, plus the new 16 cases.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add monkai_trace/integrations/bot_framework.py monkai_trace/integrations/__init__.py tests/test_bot_framework_integration.py
+git commit -m "$(cat <<'EOF'
+feat(integrations): add Bot Framework channel inference helper
+
+Adds monkai_trace.integrations.bot_framework.infer_channel — a stateless
+utility that maps a Microsoft Bot Framework activity's channelId to the
+channel string MonkAI's dashboard expects. Reusable for any consumer
+ingesting Bot Framework activities (Vivo, future integrations).
+
+Mapping covers the four channelIds in current use (msteams/directline/
+webchat/emulator); unknown values pass through lower-cased so the
+dashboard surfaces them rather than silently mislabelling. Missing or
+empty channelId returns "unknown".
+
+This is the monkai-trace-side of Fix 3 of the dedup incident
+coordination spec; the Vivo consumer adoption is a one-line change
+deferred until the Azure-Servers freeze lifts.
+
+Refs BeMonkAI/monkai-agent-hub#2
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: open PR
+
+**Files:** None (process step).
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd ~/Desktop/Monkai/monkai-trace
+git push -u origin feat/integrations/bot-framework-channel
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base main \
+  --title "feat(integrations): Bot Framework channel helper (Fix 3 of agent-hub#2)" \
+  --body "$(cat <<'EOF'
+## O que foi feito
+
+- Novo módulo `monkai_trace/integrations/bot_framework.py` com função pública `infer_channel(payload)`
+- Mapeia o `channelId` do Microsoft Bot Framework activity payload para a string de channel que o dashboard MonkAI espera (`msteams → teams`, `directline | webchat → web`, `emulator → emulator`)
+- Valores desconhecidos passam lower-cased; `channelId` ausente/vazio retorna `unknown`
+- Re-export ergonômico via `monkai_trace.integrations.infer_channel`
+- 16 casos parametrizados testando: 4 mapeamentos conhecidos × case-insensitive, passthrough de desconhecidos, missing/empty payloads, ignore de outros campos, flat-export funcional
+
+## Por que
+
+Fix 3 do incidente dedup ([BeMonkAI/monkai-agent-hub#2](https://github.com/BeMonkAI/monkai-agent-hub/issues/2)). O Vivo chatbot consumer em `Azure-Servers/.../tracing.py` hardcoda `_CHANNEL = "teams"` para todas as mensagens, mesmo as que vêm do Vivo Chat Hub web. Resultado: dashboard rotula web como Teams.
+
+Como `Azure-Servers` está em freeze (memory `feedback_azure_servers_merge_freeze.md`), este PR ship a utility no SDK. Adoção pelo Vivo consumer é follow-up de ~5 linhas pós-freeze.
+
+Master spec: `BeMonkAI/monkai-agent-hub:docs/superpowers/specs/2026-04-28-dedup-incident-coordination.md`
+
+## Como testar
+
+\`\`\`bash
+.venv/bin/pytest tests/test_bot_framework_integration.py -v
+\`\`\`
+
+Esperado: 16 passing.
+
+## Backward compatibility
+
+Aditivo. Novo módulo, nova função, nova entrada em `__all__`. Nenhum API existente foi alterado.
+
+## Versionamento
+
+Vai junto com próximo bump regular do SDK.
+
+## Adoção follow-up (issue separada pós-freeze)
+
+Quando freeze do Azure-Servers cair:
+- Remover `_CHANNEL = "teams"` em `chatbot_vivo/tracing.py:20`
+- `trace_interaction` ganha kwarg `channel: str`
+- Webhook chama `trace_interaction(..., channel=infer_channel(payload), ...)`
+
+## Checklist
+
+- [x] Testes passando (16/16 nos arquivos novos)
+- [x] Conventional Commits + Co-Authored-By Claude
+- [x] Sem mudanças quebradas no API público
+- [x] Spec + plano commitados antes do código
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Capture PR URL**
+
+`gh` prints it.
+
+---
+
+## Self-review checklist
+
+- The function is stateless, pure, no side effects.
+- The module is importable from `monkai_trace.integrations` AND `monkai_trace.integrations.bot_framework`.
+- Unknown values pass through lower-cased — verified by the parametrized tests.
+- Missing/null/empty `channelId` returns `unknown` — three explicit tests.
+- No runtime dependencies added.
+- Adoption follow-up documented in the spec for when the Azure-Servers freeze lifts.
+
+## What's next
+
+After merge: file an adoption issue in `BeMonkAI/Azure-Servers` (drafted but not opened until freeze lifts). Then Phase 1 Hub side encryption (now genuinely the largest unblocked workstream) or any other priority pick.

--- a/docs/superpowers/specs/2026-04-28-bot-framework-channel-helper-design.md
+++ b/docs/superpowers/specs/2026-04-28-bot-framework-channel-helper-design.md
@@ -1,0 +1,124 @@
+# Bot Framework Channel Inference Helper
+
+**Date:** 2026-04-28
+**Status:** Design approved, pending implementation plan
+**Sub-project of:** `monkai-agent-hub/docs/superpowers/specs/2026-04-28-dedup-incident-coordination.md` (Fix 3)
+**Repo:** `monkai-trace`
+**Affected modules:** `monkai_trace/integrations/bot_framework.py` (new)
+
+## Problem
+
+The Vivo consumer in `Azure-Servers/.../tracing.py` hardcodes `_CHANNEL = "teams"` for every conversation it traces. The same handler serves messages from Microsoft Teams and from the Vivo Chat Hub web frontend; both currently end up in the dashboard labelled "teams". This was surfaced during the dedup incident investigation (`monkai-agent-hub#2`).
+
+The fix needs the consumer to look at the inbound Bot Framework activity payload and emit the right channel string. Because `Azure-Servers` is currently under a merge freeze, this spec scopes the work to `monkai-trace` only: ship a reusable utility that any future Bot Framework consumer (Vivo, others) can drop in as a one-line replacement when their freeze lifts.
+
+## Goals
+
+- Provide a public helper `monkai_trace.integrations.bot_framework.infer_channel(payload)` that translates a Bot Framework activity's `channelId` into the channel string MonkAI's dashboard expects.
+- Map the four Bot Framework channelIds in current use:
+  - `msteams` → `teams`
+  - `directline` → `web`
+  - `webchat` → `web`
+  - `emulator` → `emulator`
+- Pass unknown values through (lower-cased) so the dashboard surfaces them rather than silently mislabelling.
+- Treat missing/empty `channelId` as `unknown`.
+- Be case-insensitive.
+- Land on the next regular `monkai-trace` minor release; no special release flow.
+
+## Non-goals
+
+- Changing `Azure-Servers/.../tracing.py`. Repo is in freeze (`feedback_azure_servers_merge_freeze.md`). The Vivo adoption is a follow-up issue tracked separately.
+- Introducing a `Channel` enum or constants module (`Channel.TEAMS`, etc.). Nice to have; defer until a second consumer lands and proves value.
+- Inferring channel from secondary signals (`from.aadObjectId`, `from.empresa`). Single signal source (`channelId`) is sufficient for the use case and avoids defensive over-engineering.
+- Renaming the historical `_NAMESPACE = "vivo-chatbot-teams"` constant in the Vivo consumer. Out of scope for this fix; would also require an alias in the Hub.
+- Backfilling historical records currently labelled `external_user_channel = "teams"` that came from the web. Operational decision tracked separately.
+
+## Design
+
+### Module placement
+
+`monkai_trace/integrations/bot_framework.py` — new file. Follows the existing `monkai_trace/integrations/` pattern. Other entries in this directory are runtime-hook classes (`MonkAIRunHooks`, `MonkAICallbackHandler`, `MonkAIAgentHooks`); this is a stateless utility function. The naming and location signal "Bot Framework integration" so that future helpers (e.g. payload extraction for `from.id`, `from.name`) can land in the same module without restructuring.
+
+### Implementation
+
+```python
+"""Bot Framework integration helpers for monkai-trace.
+
+Helps callers translate Microsoft Bot Framework activity payloads into the
+fields monkai-trace's upload_record expects. Currently scoped to channel
+inference; future helpers can land here as Bot Framework adoption grows.
+"""
+
+from typing import Mapping
+
+# Microsoft Bot Framework channelId → MonkAI channel string.
+# https://learn.microsoft.com/en-us/azure/bot-service/bot-service-channels-reference
+_CHANNEL_MAP: Mapping[str, str] = {
+    "msteams": "teams",
+    "directline": "web",
+    "webchat": "web",
+    "emulator": "emulator",
+}
+
+
+def infer_channel(payload: dict) -> str:
+    """Map a Bot Framework activity's `channelId` to a MonkAI channel string.
+
+    Unknown values pass through lower-cased so the dashboard surfaces them
+    for investigation rather than silently mislabelling. Missing or empty
+    channelId returns "unknown".
+    """
+    raw = (payload.get("channelId") or "").lower()
+    return _CHANNEL_MAP.get(raw, raw or "unknown")
+```
+
+### Export
+
+`monkai_trace/integrations/__init__.py` adds:
+
+```python
+from .bot_framework import infer_channel
+```
+
+and appends `"infer_channel"` to `__all__`. Callers may use either:
+
+```python
+from monkai_trace.integrations import infer_channel
+# or
+from monkai_trace.integrations.bot_framework import infer_channel
+```
+
+The flat re-export trades a small naming-collision risk (any future helper named `infer_channel` would clash) for ergonomic parity with the rest of the package.
+
+## Testing
+
+`tests/test_bot_framework_integration.py` (new file) covers:
+
+- Each known mapping returns the expected channel string (`msteams`/`MSTEAMS`/`MsTeams` → `teams`; `directline`/`webchat` → `web`; `emulator` → `emulator`).
+- Unknown values pass through lower-cased (`slack` → `slack`; `Slack` → `slack`).
+- Missing key returns `unknown` (`{}`).
+- Explicit `None` returns `unknown` (`{"channelId": None}`).
+- Empty string returns `unknown` (`{"channelId": ""}`).
+- Other payload fields are ignored (`{"channelId": "msteams", "from": {...}, "type": "message"}` returns `teams`).
+
+Tests use `pytest.mark.parametrize` for the table-driven cases.
+
+## Backward compatibility
+
+Purely additive — new module, new public function, new export. No existing API changed. No migration required for current callers.
+
+## Adoption follow-up
+
+When the `Azure-Servers` freeze lifts, file an issue at `BeMonkAI/Azure-Servers` referencing this PR. The Vivo consumer change is approximately five lines:
+
+1. Remove `_CHANNEL = "teams"` from `chatbot_vivo/tracing.py:20`.
+2. Add `channel: str` keyword-only parameter to `trace_interaction`.
+3. Replace `external_user_channel=_CHANNEL` with `external_user_channel=channel`.
+4. In `triggers/vivo/vivo_teams_webhook.py`, import the helper and pass `channel=infer_channel(payload)` at the `trace_interaction(...)` call site.
+
+## References
+
+- Master coordination spec: `monkai-agent-hub/docs/superpowers/specs/2026-04-28-dedup-incident-coordination.md`
+- Issue: https://github.com/BeMonkAI/monkai-agent-hub/issues/2 (Fix 3 description)
+- Vivo consumer in freeze: `Azure-Servers/apps/services/azure/gateway/client_resources/vivo/chatbot_vivo/tracing.py`
+- Bot Framework channelId reference: https://learn.microsoft.com/en-us/azure/bot-service/bot-service-channels-reference

--- a/monkai_trace/integrations/__init__.py
+++ b/monkai_trace/integrations/__init__.py
@@ -4,5 +4,12 @@ from .openai_agents import MonkAIRunHooks
 from .logging import MonkAILogHandler
 from .langchain import MonkAICallbackHandler
 from .monkai_agent import MonkAIAgentHooks
+from .bot_framework import infer_channel
 
-__all__ = ["MonkAIRunHooks", "MonkAILogHandler", "MonkAICallbackHandler", "MonkAIAgentHooks"]
+__all__ = [
+    "MonkAIRunHooks",
+    "MonkAILogHandler",
+    "MonkAICallbackHandler",
+    "MonkAIAgentHooks",
+    "infer_channel",
+]

--- a/monkai_trace/integrations/bot_framework.py
+++ b/monkai_trace/integrations/bot_framework.py
@@ -1,0 +1,36 @@
+"""Bot Framework integration helpers for monkai-trace.
+
+Helps callers translate Microsoft Bot Framework activity payloads into the
+fields monkai-trace's upload_record expects. Currently scoped to channel
+inference; future helpers can land here as Bot Framework adoption grows.
+"""
+
+from typing import Mapping
+
+# Microsoft Bot Framework channelId -> MonkAI channel string.
+# https://learn.microsoft.com/en-us/azure/bot-service/bot-service-channels-reference
+_CHANNEL_MAP: Mapping[str, str] = {
+    "msteams": "teams",
+    "directline": "web",
+    "webchat": "web",
+    "emulator": "emulator",
+}
+
+
+def infer_channel(payload: dict) -> str:
+    """Map a Bot Framework activity's ``channelId`` to a MonkAI channel string.
+
+    Unknown values pass through lower-cased so the dashboard surfaces them
+    for investigation rather than silently mislabelling. Missing or empty
+    channelId returns ``"unknown"``.
+
+    Args:
+        payload: A Bot Framework activity payload (the dict from
+            ``await req.json()`` in the webhook handler).
+
+    Returns:
+        The channel string suitable for ``MonkAIClient.upload_record``'s
+        ``external_user_channel`` argument.
+    """
+    raw = (payload.get("channelId") or "").lower()
+    return _CHANNEL_MAP.get(raw, raw or "unknown")

--- a/tests/test_bot_framework_integration.py
+++ b/tests/test_bot_framework_integration.py
@@ -1,0 +1,58 @@
+"""Tests for the Bot Framework channel inference helper."""
+
+import pytest
+from monkai_trace.integrations.bot_framework import infer_channel
+
+
+@pytest.mark.parametrize("channel_id, expected", [
+    ("msteams", "teams"),
+    ("directline", "web"),
+    ("webchat", "web"),
+    ("emulator", "emulator"),
+])
+def test_known_channel_ids_map_correctly(channel_id, expected):
+    assert infer_channel({"channelId": channel_id}) == expected
+
+
+@pytest.mark.parametrize("channel_id, expected", [
+    ("MSTEAMS", "teams"),
+    ("MsTeams", "teams"),
+    ("DirectLine", "web"),
+    ("WEBCHAT", "web"),
+])
+def test_known_channel_ids_are_case_insensitive(channel_id, expected):
+    assert infer_channel({"channelId": channel_id}) == expected
+
+
+@pytest.mark.parametrize("channel_id, expected", [
+    ("slack", "slack"),
+    ("Slack", "slack"),
+    ("custom-bot", "custom-bot"),
+])
+def test_unknown_channel_ids_pass_through_lowercased(channel_id, expected):
+    assert infer_channel({"channelId": channel_id}) == expected
+
+
+@pytest.mark.parametrize("payload", [
+    {},
+    {"channelId": None},
+    {"channelId": ""},
+])
+def test_missing_or_empty_channel_id_returns_unknown(payload):
+    assert infer_channel(payload) == "unknown"
+
+
+def test_other_payload_fields_are_ignored():
+    payload = {
+        "channelId": "msteams",
+        "from": {"id": "user-123", "aadObjectId": "aad-456"},
+        "type": "message",
+        "text": "hello",
+    }
+    assert infer_channel(payload) == "teams"
+
+
+def test_helper_is_exported_at_integrations_level():
+    """Verify the flat re-export from monkai_trace.integrations works."""
+    from monkai_trace.integrations import infer_channel as flat_export
+    assert flat_export({"channelId": "msteams"}) == "teams"


### PR DESCRIPTION
## O que foi feito

- Novo módulo `monkai_trace/integrations/bot_framework.py` com função pública `infer_channel(payload)`
- Mapeia o `channelId` do Microsoft Bot Framework activity payload para a string de channel que o dashboard MonkAI espera (`msteams → teams`, `directline | webchat → web`, `emulator → emulator`)
- Valores desconhecidos passam lower-cased; `channelId` ausente/vazio retorna `unknown`
- Re-export ergonômico via `monkai_trace.integrations.infer_channel`
- 16 casos parametrizados testando: 4 mapeamentos conhecidos × case-insensitive, passthrough de desconhecidos, missing/empty payloads, ignore de outros campos, flat-export funcional

## Por que

Fix 3 do incidente dedup ([BeMonkAI/monkai-agent-hub#2](https://github.com/BeMonkAI/monkai-agent-hub/issues/2)). O Vivo chatbot consumer em `Azure-Servers/.../tracing.py` hardcoda `_CHANNEL = "teams"` para todas as mensagens, mesmo as que vêm do Vivo Chat Hub web. Resultado: dashboard rotula web como Teams.

Como `Azure-Servers` está em freeze, este PR ship a utility no SDK. Adoção pelo Vivo consumer é follow-up de ~5 linhas pós-freeze.

Master spec: `BeMonkAI/monkai-agent-hub:docs/superpowers/specs/2026-04-28-dedup-incident-coordination.md`

## Como testar

\`\`\`bash
.venv/bin/pytest tests/test_bot_framework_integration.py -v
\`\`\`

Esperado: **16 passing**.

Regressão completa nos arquivos relevantes:
\`\`\`bash
.venv/bin/pytest tests/test_baseline_anonymizer.py tests/test_client_anonymization.py tests/test_client.py tests/test_models.py tests/test_session_manager.py tests/test_bot_framework_integration.py
\`\`\`
Esperado: **74 passing**.

## Backward compatibility

Aditivo. Novo módulo, nova função, nova entrada em `__all__`. Nenhum API existente foi alterado.

## Versionamento

Vai junto com próximo bump regular do SDK (junto com PR #2 e PR #4 que ainda estão em flight).

## Adoção follow-up (issue separada pós-freeze)

Quando freeze do Azure-Servers cair:
- Remover `_CHANNEL = "teams"` em `chatbot_vivo/tracing.py:20`
- `trace_interaction` ganha kwarg `channel: str`
- Webhook chama `trace_interaction(..., channel=infer_channel(payload), ...)`

## Checklist

- [x] Testes passando (16/16 nos arquivos novos, 74/74 incluindo regressão)
- [x] Conventional Commits + Co-Authored-By Claude
- [x] Sem mudanças quebradas no API público
- [x] Spec + plano commitados antes do código

🤖 Generated with [Claude Code](https://claude.com/claude-code)