### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to monkai-trace-python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-28
+
+### Added
+- **Baseline PII anonymization**: New `BaselineAnonymizer` (under `monkai_trace.anonymizer`) automatically redacts CPF, CNPJ, email, Brazilian phone, credit card (Luhn-validated), IPv4/IPv6, and RG from string `content` fields before transmission. Wired into both `MonkAIClient` and `AsyncMonkAIClient` via a new `_serialize_record` site that all upload paths converge through. (Phase 1 SDK)
+- **Server dedup observability**: New `strict_dedup` constructor flag on both clients (default `False`) plus a helper that inspects every upload response. Drops emit a `WARNING` log; in strict mode they raise the new `MonkAIRecordDiscardedError` (extends `MonkAIAPIError`) carrying `dropped_count`, `inserted_count`, `total_received`. The batch path (`upload_records_batch`) now propagates the strict-mode exception instead of swallowing it into a `failures` dict. (Fix 2 of dedup incident — `BeMonkAI/monkai-agent-hub#2`)
+- **Bot Framework integration helper**: New `monkai_trace.integrations.bot_framework.infer_channel(payload)` translates a Microsoft Bot Framework activity's `channelId` (`msteams`, `directline`, `webchat`, `emulator`) into the channel string MonkAI's dashboard expects. Unknown values pass through lower-cased; missing returns `"unknown"`. (Fix 3 of dedup incident)
+
+### Changed
+- `aiohttp>=3.9` is now declared as a runtime dependency (was previously imported by `AsyncMonkAIClient` but not listed — fresh installs would `ImportError`).
+
+### Limitations / known gaps
+- `BaselineAnonymizer` only redacts when `msg["content"]` is a `str`. Tool-use messages (Anthropic/OpenAI structured `content` blocks) currently bypass redaction. Tracked at `BeMonkAI/monkai-trace#3` for Phase 1.5.
+
 ## [0.2.16] - 2026-02-12
 
 ### Changed

--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.3.0"
+version = "0.4.0"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Release v0.4.0

Bump de minor consolidando o trabalho deste ciclo: Phase 1 SDK + Fix 2 + Fix 3 do incidente dedup.

### Adicionado
- **`BaselineAnonymizer`** em `monkai_trace.anonymizer` — redige PII (CPF, CNPJ, email, telefone BR, cartão Luhn-validado, IPv4/IPv6, RG) em `content` string antes do envio. Wire em ambos os clients via `_serialize_record`. (PR #2)
- **`strict_dedup`** flag + **`MonkAIRecordDiscardedError`** — SDK loga warning quando server reporta drops; em modo strict, levanta exceção estruturada com counts. Batch path propaga em vez de engolir. (PR #4, fecha o round-trip do incidente `BeMonkAI/monkai-agent-hub#2`)
- **`monkai_trace.integrations.bot_framework.infer_channel(payload)`** — utility para inferir channel do `channelId` do Microsoft Bot Framework. (PR #5, Fix 3)

### Mudado
- `aiohttp>=3.9` declarado como dep de runtime — `AsyncMonkAIClient` já importava mas não era declarado.

### Limitações conhecidas
- `BaselineAnonymizer` só processa `content` quando string. Tool-use messages com `content` em lista de blocos ainda passam intactas. Issue `BeMonkAI/monkai-trace#3` rastreia Phase 1.5.

## CI auto-publish

Workflow `publish.yml` dispara automaticamente em push para `main` quando `pyproject.toml` muda. Após merge deste PR, a release v0.4.0 sai pra PyPI sem ação manual.

## Checklist

- [x] `pyproject.toml` versão `0.4.0`
- [x] `monkai_trace/__init__.py` `__version__ = "0.4.0"`
- [x] `CHANGELOG.md` com seção 0.4.0
- [x] CI verde nos PRs anteriores (mergeados)
- [x] Sem breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)