### PR TITLE
fix(anonymizer): redact PII inside tool-use structured content

### DIFF
--- a/monkai_trace/anonymizer/baseline.py
+++ b/monkai_trace/anonymizer/baseline.py
@@ -1,8 +1,11 @@
 """Hardcoded baseline PII redaction rules. Always applied; no fetch involved."""
 
 from dataclasses import dataclass
-from typing import List, Optional, Pattern
+from typing import Any, List, Optional, Pattern
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -131,3 +134,75 @@ class BaselineAnonymizer:
         # accidentally swallow other numeric IDs.
         text = self._card_pattern.sub(_redact_card, text)
         return text
+
+    def apply_to_messages(self, messages: Any) -> List[Any]:
+        """Anonymize a list of chat messages before transmission.
+
+        Handles two shapes for ``content``:
+          * ``str`` — legacy format; redacted directly via ``apply``.
+          * ``list[dict]`` — Anthropic / OpenAI tool-use format. Each block
+            is inspected and any visible text is redacted: ``text`` blocks,
+            ``tool_use.input`` string values, and ``tool_result.content``
+            (string or nested list of blocks).
+
+        Unknown shapes are passed through unchanged with a single warning
+        emitted, so we get visibility without dropping the record.
+        """
+        if isinstance(messages, dict):
+            messages = [messages]
+        out: List[Any] = []
+        for msg in messages:
+            if not isinstance(msg, dict) or "content" not in msg:
+                out.append(msg)
+                continue
+            content = msg["content"]
+            new_msg = dict(msg)
+            if isinstance(content, str):
+                new_msg["content"] = self.apply(content)
+            elif isinstance(content, list):
+                new_msg["content"] = [self._anonymize_block(b) for b in content]
+            else:
+                logger.warning(
+                    "BaselineAnonymizer: skipping message with unsupported content "
+                    "type %s; PII may be transmitted unredacted",
+                    type(content).__name__,
+                )
+            out.append(new_msg)
+        return out
+
+    def _anonymize_block(self, block: Any) -> Any:
+        """Anonymize a single content block from a tool-use style message."""
+        if not isinstance(block, dict):
+            return block
+        new_block = dict(block)
+        block_type = new_block.get("type")
+        if block_type == "text" and isinstance(new_block.get("text"), str):
+            new_block["text"] = self.apply(new_block["text"])
+        elif block_type == "tool_use" and isinstance(new_block.get("input"), dict):
+            new_block["input"] = self._anonymize_dict(new_block["input"])
+        elif block_type == "tool_result":
+            inner = new_block.get("content")
+            if isinstance(inner, str):
+                new_block["content"] = self.apply(inner)
+            elif isinstance(inner, list):
+                new_block["content"] = [self._anonymize_block(b) for b in inner]
+        return new_block
+
+    def _anonymize_dict(self, d: dict) -> dict:
+        """Recursively redact string values in a dict (e.g. tool_use.input)."""
+        out: dict = {}
+        for k, v in d.items():
+            if isinstance(v, str):
+                out[k] = self.apply(v)
+            elif isinstance(v, dict):
+                out[k] = self._anonymize_dict(v)
+            elif isinstance(v, list):
+                out[k] = [
+                    self.apply(item) if isinstance(item, str)
+                    else self._anonymize_dict(item) if isinstance(item, dict)
+                    else item
+                    for item in v
+                ]
+            else:
+                out[k] = v
+        return out

--- a/monkai_trace/async_client.py
+++ b/monkai_trace/async_client.py
@@ -166,18 +166,12 @@ class AsyncMonkAIClient:
         return await self._upload_single_record(record)
     
     def _anonymize_messages(self, messages):
-        """Apply BaselineAnonymizer to every message content. Returns a new list."""
-        if isinstance(messages, dict):
-            messages = [messages]
-        out = []
-        for msg in messages:
-            if isinstance(msg, dict) and "content" in msg and isinstance(msg["content"], str):
-                new_msg = dict(msg)
-                new_msg["content"] = self._anonymizer.apply(msg["content"])
-                out.append(new_msg)
-            else:
-                out.append(msg)
-        return out
+        """Apply BaselineAnonymizer to every message content. Returns a new list.
+
+        Supports both string content and Anthropic/OpenAI tool-use list-of-blocks
+        content; see ``BaselineAnonymizer.apply_to_messages``.
+        """
+        return self._anonymizer.apply_to_messages(messages)
 
     def _serialize_record(self, record: ConversationRecord) -> Dict[str, Any]:
         """Serialize a record and anonymize its message content before transmission."""

--- a/monkai_trace/client.py
+++ b/monkai_trace/client.py
@@ -306,18 +306,12 @@ class MonkAIClient:
         raise MonkAIAPIError("Request failed after all retries")
     
     def _anonymize_messages(self, messages):
-        """Apply BaselineAnonymizer to every message content. Returns a new list."""
-        if isinstance(messages, dict):
-            messages = [messages]
-        out = []
-        for msg in messages:
-            if isinstance(msg, dict) and "content" in msg and isinstance(msg["content"], str):
-                new_msg = dict(msg)
-                new_msg["content"] = self._anonymizer.apply(msg["content"])
-                out.append(new_msg)
-            else:
-                out.append(msg)
-        return out
+        """Apply BaselineAnonymizer to every message content. Returns a new list.
+
+        Supports both string content and Anthropic/OpenAI tool-use list-of-blocks
+        content; see ``BaselineAnonymizer.apply_to_messages``.
+        """
+        return self._anonymizer.apply_to_messages(messages)
 
     def _serialize_record(self, record: ConversationRecord) -> Dict:
         """Serialize a record and anonymize its message content before transmission."""

--- a/monkai_trace/models.py
+++ b/monkai_trace/models.py
@@ -8,7 +8,15 @@ from datetime import datetime
 class Message(BaseModel):
     """Single message in a conversation"""
     role: str = Field(..., description="Role: user, assistant, tool, system")
-    content: Optional[Union[str, Dict]] = Field(None, description="Message content")
+    # ``content`` may be:
+    #   * ``str`` — legacy / OpenAI chat-completions format
+    #   * ``Dict`` — single structured payload (rare)
+    #   * ``List[Dict]`` — Anthropic / OpenAI tool-use format with text /
+    #     tool_use / tool_result blocks. Accepting it here lets the SDK
+    #     anonymize structured content before transmission (issue #3).
+    content: Optional[Union[str, List[Dict[str, Any]], Dict[str, Any]]] = Field(
+        None, description="Message content"
+    )
     sender: Optional[str] = Field(None, description="Agent/user that sent this")
     tool_calls: Optional[List[Dict]] = None
     tool_call_id: Optional[str] = None

--- a/tests/test_baseline_anonymizer.py
+++ b/tests/test_baseline_anonymizer.py
@@ -114,3 +114,117 @@ def test_cpf_check_digits_valid(digits, expected):
 ])
 def test_luhn_valid(digits, expected):
     assert _luhn_valid(digits) is expected
+
+
+# ---------------------------------------------------------------------------
+# apply_to_messages — list-of-blocks content (Anthropic/OpenAI tool-use)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_to_messages_redacts_string_content():
+    a = BaselineAnonymizer()
+    out = a.apply_to_messages([{"role": "user", "content": "CPF 123.456.789-09"}])
+    assert out == [{"role": "user", "content": "CPF [CPF]"}]
+
+
+def test_apply_to_messages_redacts_text_block_in_list_content():
+    a = BaselineAnonymizer()
+    msg = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "O CPF do cliente e 123.456.789-09"},
+            {"type": "tool_use", "id": "x", "name": "lookup", "input": {"cpf": "12345678909"}},
+        ],
+    }
+    out = a.apply_to_messages([msg])
+    blocks = out[0]["content"]
+    assert blocks[0]["text"] == "O CPF do cliente e [CPF]"
+    # tool_use input is also scrubbed recursively
+    assert blocks[1]["input"]["cpf"] == "[CPF]"
+
+
+def test_apply_to_messages_redacts_tool_result_content_string():
+    a = BaselineAnonymizer()
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": "x", "content": "email arthur@monkai.com.br"}
+        ],
+    }
+    out = a.apply_to_messages([msg])
+    assert out[0]["content"][0]["content"] == "email [EMAIL]"
+
+
+def test_apply_to_messages_redacts_tool_result_content_blocks():
+    a = BaselineAnonymizer()
+    msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "x",
+                "content": [{"type": "text", "text": "phone +55 11 91234-5678"}],
+            }
+        ],
+    }
+    out = a.apply_to_messages([msg])
+    inner = out[0]["content"][0]["content"][0]
+    assert inner["text"] == "phone [PHONE]"
+
+
+def test_apply_to_messages_redacts_nested_dict_in_tool_use_input():
+    a = BaselineAnonymizer()
+    msg = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "x",
+                "name": "search",
+                "input": {
+                    "query": "find CPF 123.456.789-09",
+                    "filters": {"email": "arthur@monkai.com.br"},
+                    "tags": ["12.345.678/0001-95"],
+                },
+            }
+        ],
+    }
+    out = a.apply_to_messages([msg])
+    inp = out[0]["content"][0]["input"]
+    assert inp["query"] == "find CPF [CPF]"
+    assert inp["filters"]["email"] == "[EMAIL]"
+    assert inp["tags"] == ["[CNPJ]"]
+
+
+def test_apply_to_messages_passes_through_unknown_block_types():
+    a = BaselineAnonymizer()
+    msg = {"role": "assistant", "content": [{"type": "image", "source": {"data": "..."}}]}
+    out = a.apply_to_messages([msg])
+    assert out == [msg]
+
+
+def test_apply_to_messages_warns_on_unsupported_content_shape(caplog):
+    a = BaselineAnonymizer()
+    msg = {"role": "user", "content": 42}  # neither str nor list
+    with caplog.at_level("WARNING", logger="monkai_trace.anonymizer.baseline"):
+        out = a.apply_to_messages([msg])
+    # Message is preserved (unchanged) but a warning is emitted
+    assert out[0]["content"] == 42
+    assert any("unsupported content" in rec.message for rec in caplog.records)
+
+
+def test_apply_to_messages_accepts_single_dict():
+    a = BaselineAnonymizer()
+    out = a.apply_to_messages({"role": "user", "content": "CPF 123.456.789-09"})
+    assert out == [{"role": "user", "content": "CPF [CPF]"}]
+
+
+def test_apply_to_messages_does_not_mutate_input():
+    a = BaselineAnonymizer()
+    original = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "CPF 123.456.789-09"}],
+    }
+    a.apply_to_messages([original])
+    # input untouched
+    assert original["content"][0]["text"] == "CPF 123.456.789-09"

--- a/tests/test_client_anonymization.py
+++ b/tests/test_client_anonymization.py
@@ -33,3 +33,56 @@ def test_upload_record_anonymizes_message_content_before_send():
     assert "arthur@monkai.com.br" not in serialized
     assert "[CPF]" in serialized
     assert "[EMAIL]" in serialized
+
+
+def test_upload_record_anonymizes_tool_use_blocks_before_send():
+    """Anthropic/OpenAI tool-use messages send `content` as a list of blocks.
+
+    Verify the SDK redacts text blocks and tool_use.input string values
+    instead of letting structured content slip through (issue #3).
+    """
+    client = MonkAIClient(tracer_token="tk_test")
+    captured_payload = {}
+
+    def fake_request(method, url, json=None, **kwargs):
+        if json is not None:
+            captured_payload.update(json)
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.reason = "Created"
+        resp.json.return_value = {"inserted_count": 1}
+        return resp
+
+    with patch("requests.Session.request", side_effect=fake_request):
+        client.upload_record(
+            namespace="test",
+            agent="bot",
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "CPF do cliente: 123.456.789-09"},
+                        {
+                            "type": "tool_use",
+                            "id": "tu_1",
+                            "name": "lookup",
+                            "input": {"email": "arthur@monkai.com.br"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu_1", "content": "found 12.345.678/0001-95"}
+                    ],
+                },
+            ],
+        )
+
+    serialized = json.dumps(captured_payload)
+    assert "123.456.789-09" not in serialized
+    assert "arthur@monkai.com.br" not in serialized
+    assert "12.345.678/0001-95" not in serialized
+    assert "[CPF]" in serialized
+    assert "[EMAIL]" in serialized
+    assert "[CNPJ]" in serialized


### PR DESCRIPTION
## O que foi feito

`BaselineAnonymizer` so tratava `content: str`. Mensagens estilo Anthropic / OpenAI tool-use enviam `content` como `list[dict]` (blocos `text`, `tool_use`, `tool_result`) e a PII passava intacta. Alem disso, o modelo Pydantic `Message` nem aceitava list content, entao essas mensagens eram rejeitadas no `upload_record`.

Correcao em duas camadas:

1. **Modelo** — `Message.content` agora aceita `List[Dict[str, Any]]` alem de `str` e `Dict`. Mensagens tool-use deixam de ser rejeitadas na validacao.

2. **Anonymizer** — Novo `BaselineAnonymizer.apply_to_messages()` que cobre:
   - `content: str` (comportamento original, preservado)
   - bloco `text` → redige `block["text"]`
   - bloco `tool_use` → redige recursivamente `block["input"]` (dict de strings, dicts aninhados e listas de strings/dicts)
   - bloco `tool_result` → redige `content` (string ou lista de blocos aninhados)
   - shapes desconhecidos passam intactos com um `logger.warning` para observabilidade

Ambos `MonkAIClient` e `AsyncMonkAIClient` agora delegam `_anonymize_messages` ao anonymizer — elimina a duplicacao identica entre os dois clients.

## Por que

PR #2 introduziu o BaselineAnonymizer cobrindo apenas string content. Tool-use e dominante em Claude/Anthropic SDK e tambem usado em OpenAI Responses API. Sem essa correcao, qualquer agente baseado em ferramentas vazava PII (CPF, email, telefone, cartao) para o wire.

Issue #3 documentou a limitacao para Fase 1.5.

## Como testar

```bash
pytest tests/test_baseline_anonymizer.py tests/test_client_anonymization.py -q
```

Cobertura adicionada:
- `apply_to_messages` com string, list-of-blocks, single-dict, missing content
- Redacao em `text`, `tool_use.input` (incluindo dict aninhado e list de strings), `tool_result.content` (string e nested blocks)
- Bloco com tipo desconhecido (e.g. `image`) passa intacto
- Conteudo nao-string nao-list emite `logger.warning`
- `_anonymize_messages` nao muta o input
- Test E2E pelo `upload_record` confirma que CPF/email/CNPJ em tool-use sao redacted antes do request

## Checklist

- [x] Tests passando (`pytest tests/test_baseline_anonymizer.py tests/test_client_anonymization.py -q`): 46 passed
- [x] Suite completa: 8 falhas pre-existentes em `test_logging_integration.py` (nao relacionadas — confirmado em main com `git stash`)
- [x] Sem mudanca de API publica — `_anonymize_messages` em ambos clients ainda existe e devolve a mesma forma para inputs string
- [x] `MonkAIClient` e `AsyncMonkAIClient` em sincronia (mesma logica via anonymizer)

Closes #3