### PR TITLE
feat(anonymizer): RulesClient + custom rules pipeline (Phase 2 SDK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to monkai-trace-python will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-28
+
+### Added
+- **Per-tenant custom anonymization rules (Phase 2 SDK)**: New `RulesClient` (under `monkai_trace.anonymizer`) fetches `{toggles, custom: [{name, pattern, replacement}], version}` from the Hub at `GET /v1/anonymization-rules` and caches the document in process memory with a configurable TTL (default 300s). Both `MonkAIClient` and `AsyncMonkAIClient` accept opt-in `rules_url=` (or a pre-built `rules_client=`) — when set, the upload pipeline runs the baseline first, then applies tenant-defined custom regex on top, and stamps `anonymization_version=N` on the outbound payload so the edge function can detect drift and re-apply server-side. (Issue #8)
+- **Baseline class toggles**: When the rules document carries `toggles: {<class>: false}` (e.g. `{"email": false}`), the SDK skips that baseline class on outbound content. Lets a B2B tenant preserve emails (or other classes) without forking the SDK.
+- **`MonkAIAnonymizerNotReady` exception**: Raised when `RulesClient.get()` has never succeeded — the upload pipeline blocks instead of transmitting raw content. After the first success, transient fetch failures fall back to the cached document and emit a warning log.
+
+### Compatibility
+- Default behaviour unchanged from 0.4.0: clients constructed without `rules_url=` (or `rules_client=`) skip the fetch entirely, run baseline-only redaction, and do not stamp `anonymization_version` on payloads.
+
 ## [0.4.0] - 2026-04-28
 
 ### Added

--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -14,9 +14,10 @@ from .models import (
 )
 from .session_manager import SessionManager, PersistentSessionManager
 from .exceptions import (
+    MonkAIAnonymizerNotReady,
     MonkAIRecordDiscardedError,
 )
-from monkai_trace.anonymizer import BaselineAnonymizer
+from monkai_trace.anonymizer import BaselineAnonymizer, RulesClient
 
 try:
     from .async_client import AsyncMonkAIClient
@@ -44,7 +45,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",
@@ -60,5 +61,7 @@ __all__ = [
     "CopilotTracer",
     "OpenClawTracer",
     "BaselineAnonymizer",
+    "RulesClient",
+    "MonkAIAnonymizerNotReady",
     "MonkAIRecordDiscardedError",
 ]

--- a/monkai_trace/anonymizer/__init__.py
+++ b/monkai_trace/anonymizer/__init__.py
@@ -1,5 +1,6 @@
 """Client-side PII anonymization for monkai-trace."""
 
 from monkai_trace.anonymizer.baseline import BaselineAnonymizer, BASELINE_RULES
+from monkai_trace.anonymizer.rules_client import RulesClient
 
-__all__ = ["BaselineAnonymizer", "BASELINE_RULES"]
+__all__ = ["BaselineAnonymizer", "BASELINE_RULES", "RulesClient"]

--- a/monkai_trace/anonymizer/baseline.py
+++ b/monkai_trace/anonymizer/baseline.py
@@ -1,7 +1,7 @@
 """Hardcoded baseline PII redaction rules. Always applied; no fetch involved."""
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Pattern
+from typing import Any, Iterable, List, Optional, Pattern, Set
 import logging
 import re
 
@@ -122,20 +122,35 @@ class BaselineAnonymizer:
         self._card_pattern = _CARD_PATTERN
         self._cpf_pattern = _CPF_PATTERN
 
-    def apply(self, text: str) -> str:
+    def apply(self, text: str, disabled_classes: Optional[Iterable[str]] = None) -> str:
         if not text:
             return text
+        disabled = self._coerce_disabled(disabled_classes)
         # CPF runs first via a callable that validates the check digits.
         # This prevents 11-digit phone numbers from being mistaken for CPFs.
-        text = self._cpf_pattern.sub(_redact_cpf, text)
+        if "cpf" not in disabled:
+            text = self._cpf_pattern.sub(_redact_cpf, text)
         for rule in self._rules:
+            if rule.name in disabled:
+                continue
             text = rule.pattern.sub(rule.replacement, text)
         # CARD runs last via a callable that enforces Luhn so it does not
         # accidentally swallow other numeric IDs.
-        text = self._card_pattern.sub(_redact_card, text)
+        if "credit_card" not in disabled and "card" not in disabled:
+            text = self._card_pattern.sub(_redact_card, text)
         return text
 
-    def apply_to_messages(self, messages: Any) -> List[Any]:
+    @staticmethod
+    def _coerce_disabled(disabled_classes: Optional[Iterable[str]]) -> Set[str]:
+        if not disabled_classes:
+            return set()
+        return {c.lower() for c in disabled_classes}
+
+    def apply_to_messages(
+        self,
+        messages: Any,
+        disabled_classes: Optional[Iterable[str]] = None,
+    ) -> List[Any]:
         """Anonymize a list of chat messages before transmission.
 
         Handles two shapes for ``content``:
@@ -148,6 +163,7 @@ class BaselineAnonymizer:
         Unknown shapes are passed through unchanged with a single warning
         emitted, so we get visibility without dropping the record.
         """
+        disabled = self._coerce_disabled(disabled_classes)
         if isinstance(messages, dict):
             messages = [messages]
         out: List[Any] = []
@@ -158,9 +174,9 @@ class BaselineAnonymizer:
             content = msg["content"]
             new_msg = dict(msg)
             if isinstance(content, str):
-                new_msg["content"] = self.apply(content)
+                new_msg["content"] = self.apply(content, disabled)
             elif isinstance(content, list):
-                new_msg["content"] = [self._anonymize_block(b) for b in content]
+                new_msg["content"] = [self._anonymize_block(b, disabled) for b in content]
             else:
                 logger.warning(
                     "BaselineAnonymizer: skipping message with unsupported content "
@@ -170,36 +186,36 @@ class BaselineAnonymizer:
             out.append(new_msg)
         return out
 
-    def _anonymize_block(self, block: Any) -> Any:
+    def _anonymize_block(self, block: Any, disabled: Set[str]) -> Any:
         """Anonymize a single content block from a tool-use style message."""
         if not isinstance(block, dict):
             return block
         new_block = dict(block)
         block_type = new_block.get("type")
         if block_type == "text" and isinstance(new_block.get("text"), str):
-            new_block["text"] = self.apply(new_block["text"])
+            new_block["text"] = self.apply(new_block["text"], disabled)
         elif block_type == "tool_use" and isinstance(new_block.get("input"), dict):
-            new_block["input"] = self._anonymize_dict(new_block["input"])
+            new_block["input"] = self._anonymize_dict(new_block["input"], disabled)
         elif block_type == "tool_result":
             inner = new_block.get("content")
             if isinstance(inner, str):
-                new_block["content"] = self.apply(inner)
+                new_block["content"] = self.apply(inner, disabled)
             elif isinstance(inner, list):
-                new_block["content"] = [self._anonymize_block(b) for b in inner]
+                new_block["content"] = [self._anonymize_block(b, disabled) for b in inner]
         return new_block
 
-    def _anonymize_dict(self, d: dict) -> dict:
+    def _anonymize_dict(self, d: dict, disabled: Set[str]) -> dict:
         """Recursively redact string values in a dict (e.g. tool_use.input)."""
         out: dict = {}
         for k, v in d.items():
             if isinstance(v, str):
-                out[k] = self.apply(v)
+                out[k] = self.apply(v, disabled)
             elif isinstance(v, dict):
-                out[k] = self._anonymize_dict(v)
+                out[k] = self._anonymize_dict(v, disabled)
             elif isinstance(v, list):
                 out[k] = [
-                    self.apply(item) if isinstance(item, str)
-                    else self._anonymize_dict(item) if isinstance(item, dict)
+                    self.apply(item, disabled) if isinstance(item, str)
+                    else self._anonymize_dict(item, disabled) if isinstance(item, dict)
                     else item
                     for item in v
                 ]

--- a/monkai_trace/anonymizer/rules_client.py
+++ b/monkai_trace/anonymizer/rules_client.py
@@ -1,0 +1,146 @@
+"""Per-tenant custom anonymization rules fetched from the Hub.
+
+The SDK fetches rules from ``GET /v1/anonymization-rules`` and applies them
+on top of the baseline regex set before transmission. Rules are cached in
+process memory with a TTL (default 300s) so the typical request path makes
+zero network calls.
+
+If the fetch has never succeeded, ``get()`` raises ``MonkAIAnonymizerNotReady``
+so the upload pipeline can block instead of sending raw content. If the
+fetch fails after at least one successful fetch, the cached value is
+returned and a warning is logged — the SDK degrades to "stale rules" rather
+than hard-failing for a transient Hub outage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+from monkai_trace.exceptions import MonkAIAnonymizerNotReady
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_TTL_SECONDS = 300
+
+
+class RulesClient:
+    """Fetches and caches per-tenant anonymization rules.
+
+    Args:
+        tracer_token: SDK tracer token (``tk_...``) used to authenticate the fetch.
+        hub_url: Base URL of the Hub edge function exposing
+            ``/v1/anonymization-rules`` (typically the same value as
+            ``MonkAIClient.base_url``).
+        ttl_seconds: How long a successful fetch is reused before a refetch
+            is attempted. Defaults to 300s.
+        timeout: Per-request timeout in seconds. Defaults to 5.
+    """
+
+    DEFAULT_RULES: Dict[str, Any] = {
+        "version": 0,
+        "rules": {"toggles": {}, "custom": []},
+    }
+
+    def __init__(
+        self,
+        tracer_token: str,
+        hub_url: str,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        timeout: int = 5,
+    ):
+        self._tracer_token = tracer_token
+        self._hub_url = hub_url.rstrip("/")
+        self._ttl = ttl_seconds
+        self._timeout = timeout
+        self._cache: Optional[Dict[str, Any]] = None
+        self._cached_at: float = 0.0
+        self._lock = threading.Lock()
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self._hub_url}/v1/anonymization-rules"
+
+    def get(self) -> Dict[str, Any]:
+        """Return current rules document, refetching when the cache is stale.
+
+        Falls back to the last successful cache on transient failure. Raises
+        ``MonkAIAnonymizerNotReady`` if no successful fetch has ever happened.
+        """
+        with self._lock:
+            now = time.time()
+            if self._cache is not None and (now - self._cached_at) < self._ttl:
+                return self._cache
+
+            try:
+                payload = self._fetch_sync()
+            except Exception:
+                logger.exception(
+                    "RulesClient: fetch from %s failed", self.endpoint
+                )
+                if self._cache is not None:
+                    logger.warning(
+                        "RulesClient: serving stale cache (age=%.1fs) — "
+                        "Hub fetch failed",
+                        now - self._cached_at,
+                    )
+                    return self._cache
+                raise MonkAIAnonymizerNotReady(
+                    f"Could not fetch anonymization rules from {self.endpoint}; "
+                    "blocking upload to avoid sending raw content"
+                )
+
+            self._cache = payload
+            self._cached_at = now
+            return payload
+
+    async def get_async(self) -> Dict[str, Any]:
+        """Async variant of ``get()`` — runs the blocking fetch in a worker thread.
+
+        Using a thread executor (instead of pulling in ``aiohttp`` here) keeps
+        the rules-fetch path identical between sync and async clients and
+        avoids cross-loop session reuse issues.
+        """
+        return await asyncio.to_thread(self.get)
+
+    def invalidate(self) -> None:
+        """Force the next call to ``get()`` to refetch."""
+        with self._lock:
+            self._cached_at = 0.0
+
+    def _fetch_sync(self) -> Dict[str, Any]:
+        response = requests.get(
+            self.endpoint,
+            headers={
+                "tracer_token": self._tracer_token,
+                "Content-Type": "application/json",
+            },
+            timeout=self._timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return self._normalize(data)
+
+    @staticmethod
+    def _normalize(data: Any) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"RulesClient: unexpected response type {type(data).__name__}"
+            )
+        version = data.get("version", 0)
+        rules = data.get("rules") or {}
+        toggles = rules.get("toggles") if isinstance(rules, dict) else None
+        custom = rules.get("custom") if isinstance(rules, dict) else None
+        return {
+            "version": int(version) if isinstance(version, (int, float)) else 0,
+            "rules": {
+                "toggles": toggles if isinstance(toggles, dict) else {},
+                "custom": custom if isinstance(custom, list) else [],
+            },
+        }

--- a/monkai_trace/async_client.py
+++ b/monkai_trace/async_client.py
@@ -10,13 +10,15 @@ from pathlib import Path
 
 from .models import ConversationRecord, LogEntry
 from .exceptions import (
+    MonkAIAnonymizerNotReady,
     MonkAIAPIError,
     MonkAIValidationError,
     MonkAIAuthError,
     MonkAIRecordDiscardedError,
 )
 from .file_handlers import FileHandler
-from .anonymizer import BaselineAnonymizer
+from .anonymizer import BaselineAnonymizer, RulesClient
+from .client import _apply_custom_rules_to_message
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,9 @@ class AsyncMonkAIClient:
         timeout: int = 30,
         max_retries: int = 3,
         strict_dedup: bool = False,
+        rules_url: Optional[str] = None,
+        rules_ttl_seconds: int = 300,
+        rules_client: Optional[RulesClient] = None,
     ):
         """
         Initialize async MonkAI client.
@@ -56,6 +61,12 @@ class AsyncMonkAIClient:
             max_retries: Maximum number of retry attempts
             strict_dedup: If True, raise MonkAIRecordDiscardedError when the
                 server drops records as duplicates. Default False (warn only).
+            rules_url: Hub URL exposing ``/v1/anonymization-rules``. When set,
+                the SDK fetches per-tenant custom rules and applies them on
+                top of the baseline before transmission.
+            rules_ttl_seconds: How long a successful rules fetch is reused.
+            rules_client: Optional pre-built ``RulesClient`` (overrides
+                ``rules_url``/``rules_ttl_seconds`` for full control).
         """
         if not tracer_token or not tracer_token.startswith("tk_"):
             raise MonkAIValidationError("Invalid tracer_token format. Must start with 'tk_'")
@@ -67,6 +78,17 @@ class AsyncMonkAIClient:
         self._session: Optional[aiohttp.ClientSession] = None
         self._anonymizer = BaselineAnonymizer()
         self._strict_dedup = strict_dedup
+        if rules_client is not None:
+            self._rules_client: Optional[RulesClient] = rules_client
+        elif rules_url is not None:
+            self._rules_client = RulesClient(
+                tracer_token=tracer_token,
+                hub_url=rules_url,
+                ttl_seconds=rules_ttl_seconds,
+            )
+        else:
+            self._rules_client = None
+        self._last_anonymization_version: Optional[int] = None
     
     async def __aenter__(self):
         """Async context manager entry"""
@@ -165,19 +187,34 @@ class AsyncMonkAIClient:
         
         return await self._upload_single_record(record)
     
-    def _anonymize_messages(self, messages):
-        """Apply BaselineAnonymizer to every message content. Returns a new list.
+    async def _fetch_rules_state(self):
+        """Return (disabled_classes, custom_rules). Updates ``_last_anonymization_version``."""
+        if self._rules_client is None:
+            self._last_anonymization_version = None
+            return set(), []
+        rules_doc = await self._rules_client.get_async()
+        rules = rules_doc.get("rules", {})
+        toggles = rules.get("toggles", {}) or {}
+        disabled = {name for name, enabled in toggles.items() if enabled is False}
+        custom = rules.get("custom") or []
+        self._last_anonymization_version = int(rules_doc.get("version", 0))
+        return disabled, custom
 
-        Supports both string content and Anthropic/OpenAI tool-use list-of-blocks
-        content; see ``BaselineAnonymizer.apply_to_messages``.
-        """
-        return self._anonymizer.apply_to_messages(messages)
+    async def _anonymize_messages(self, messages):
+        """Apply baseline + per-tenant custom rules to every message content."""
+        disabled, custom = await self._fetch_rules_state()
+        out = self._anonymizer.apply_to_messages(messages, disabled_classes=disabled)
+        if custom:
+            out = [_apply_custom_rules_to_message(m, custom) for m in out]
+        return out
 
-    def _serialize_record(self, record: ConversationRecord) -> Dict[str, Any]:
+    async def _serialize_record(self, record: ConversationRecord) -> Dict[str, Any]:
         """Serialize a record and anonymize its message content before transmission."""
         payload = record.to_api_format()
         if "msg" in payload and payload["msg"] is not None:
-            payload["msg"] = self._anonymize_messages(payload["msg"])
+            payload["msg"] = await self._anonymize_messages(payload["msg"])
+        if self._last_anonymization_version is not None:
+            payload["anonymization_version"] = self._last_anonymization_version
         return payload
 
     def _check_dedup_response(self, response_dict: Dict, total_records: int) -> Dict:
@@ -211,10 +248,11 @@ class AsyncMonkAIClient:
 
     async def _upload_single_record(self, record: ConversationRecord) -> Dict[str, Any]:
         """Upload a single record"""
+        serialized = await self._serialize_record(record)
         result = await self._make_request(
             "POST",
             "records/upload",
-            data={"records": [self._serialize_record(record)]}
+            data={"records": [serialized]}
         )
         return self._check_dedup_response(result, total_records=1)
     
@@ -275,7 +313,7 @@ class AsyncMonkAIClient:
     
     async def _upload_records_chunk(self, records: List[ConversationRecord]) -> Dict[str, Any]:
         """Upload a chunk of records"""
-        records_data = [self._serialize_record(r) for r in records]
+        records_data = [await self._serialize_record(r) for r in records]
         result = await self._make_request("POST", "records/upload", data={"records": records_data})
         return self._check_dedup_response(result, total_records=len(records))
     

--- a/monkai_trace/client.py
+++ b/monkai_trace/client.py
@@ -1,5 +1,6 @@
 """Synchronous client for MonkAI API"""
 
+import re
 import time
 import logging
 import requests
@@ -7,8 +8,9 @@ from typing import List, Optional, Union, Dict
 from pathlib import Path
 from .models import ConversationRecord, LogEntry, TokenUsage
 from .file_handlers import FileHandler
-from .anonymizer import BaselineAnonymizer
+from .anonymizer import BaselineAnonymizer, RulesClient
 from .exceptions import (
+    MonkAIAnonymizerNotReady,
     MonkAIAuthError,
     MonkAIValidationError,
     MonkAIServerError,
@@ -18,6 +20,87 @@ from .exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _compile_custom_rules(custom):
+    """Compile custom rule patterns once per call. Skips invalid regex with a warning."""
+    compiled = []
+    for r in custom:
+        if not isinstance(r, dict):
+            continue
+        pattern = r.get("pattern")
+        replacement = r.get("replacement", "[REDACTED]")
+        if not isinstance(pattern, str):
+            continue
+        try:
+            compiled.append((re.compile(pattern), replacement))
+        except re.error:
+            logger.warning(
+                "RulesClient: skipping invalid custom regex %r (%s)",
+                r.get("name", pattern),
+                pattern,
+            )
+    return compiled
+
+
+def _apply_custom_to_text(text, compiled):
+    if not isinstance(text, str) or not text:
+        return text
+    out = text
+    for pattern, replacement in compiled:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+def _apply_custom_rules_to_message(msg, custom):
+    """Apply custom rules over an already-baseline-redacted message."""
+    compiled = _compile_custom_rules(custom)
+    if not compiled or not isinstance(msg, dict) or "content" not in msg:
+        return msg
+    content = msg["content"]
+    new_msg = dict(msg)
+    if isinstance(content, str):
+        new_msg["content"] = _apply_custom_to_text(content, compiled)
+    elif isinstance(content, list):
+        new_msg["content"] = [_apply_custom_to_block(b, compiled) for b in content]
+    return new_msg
+
+
+def _apply_custom_to_block(block, compiled):
+    if not isinstance(block, dict):
+        return block
+    new_block = dict(block)
+    block_type = new_block.get("type")
+    if block_type == "text" and isinstance(new_block.get("text"), str):
+        new_block["text"] = _apply_custom_to_text(new_block["text"], compiled)
+    elif block_type == "tool_use" and isinstance(new_block.get("input"), dict):
+        new_block["input"] = _apply_custom_to_dict(new_block["input"], compiled)
+    elif block_type == "tool_result":
+        inner = new_block.get("content")
+        if isinstance(inner, str):
+            new_block["content"] = _apply_custom_to_text(inner, compiled)
+        elif isinstance(inner, list):
+            new_block["content"] = [_apply_custom_to_block(b, compiled) for b in inner]
+    return new_block
+
+
+def _apply_custom_to_dict(d, compiled):
+    out = {}
+    for k, v in d.items():
+        if isinstance(v, str):
+            out[k] = _apply_custom_to_text(v, compiled)
+        elif isinstance(v, dict):
+            out[k] = _apply_custom_to_dict(v, compiled)
+        elif isinstance(v, list):
+            out[k] = [
+                _apply_custom_to_text(item, compiled) if isinstance(item, str)
+                else _apply_custom_to_dict(item, compiled) if isinstance(item, dict)
+                else item
+                for item in v
+            ]
+        else:
+            out[k] = v
+    return out
 
 
 class MonkAIClient:
@@ -41,6 +124,9 @@ class MonkAIClient:
         timeout: int = 30,
         max_retries: int = 3,
         strict_dedup: bool = False,
+        rules_url: Optional[str] = None,
+        rules_ttl_seconds: int = 300,
+        rules_client: Optional[RulesClient] = None,
     ):
         """
         Initialize MonkAI client
@@ -51,6 +137,14 @@ class MonkAIClient:
             timeout: Request timeout in seconds
             max_retries: Maximum number of retry attempts
             strict_dedup: If True, raise MonkAIRecordDiscardedError when the server reports drops
+            rules_url: Hub URL exposing ``/v1/anonymization-rules``. When set,
+                the SDK fetches per-tenant custom rules and applies them on
+                top of the baseline before transmission. Leave ``None`` to
+                preserve Phase 1 behaviour (baseline only).
+            rules_ttl_seconds: How long a successful rules fetch is reused
+                before being refreshed. Defaults to 300s.
+            rules_client: Optional pre-built ``RulesClient`` (overrides
+                ``rules_url``/``rules_ttl_seconds`` for full control).
         """
         self.tracer_token = tracer_token
         self.base_url = base_url or self.BASE_URL
@@ -63,6 +157,17 @@ class MonkAIClient:
         })
         self._anonymizer = BaselineAnonymizer()
         self._strict_dedup = strict_dedup
+        if rules_client is not None:
+            self._rules_client: Optional[RulesClient] = rules_client
+        elif rules_url is not None:
+            self._rules_client = RulesClient(
+                tracer_token=tracer_token,
+                hub_url=rules_url,
+                ttl_seconds=rules_ttl_seconds,
+            )
+        else:
+            self._rules_client = None
+        self._last_anonymization_version: Optional[int] = None
     
     # ==================== RECORD METHODS ====================
     
@@ -306,18 +411,41 @@ class MonkAIClient:
         raise MonkAIAPIError("Request failed after all retries")
     
     def _anonymize_messages(self, messages):
-        """Apply BaselineAnonymizer to every message content. Returns a new list.
+        """Apply baseline + per-tenant custom rules to every message content.
 
-        Supports both string content and Anthropic/OpenAI tool-use list-of-blocks
-        content; see ``BaselineAnonymizer.apply_to_messages``.
+        When a ``RulesClient`` is configured, ``self._last_anonymization_version``
+        is updated as a side effect so the upload payload can stamp it.
         """
-        return self._anonymizer.apply_to_messages(messages)
+        disabled, custom = self._fetch_rules_state()
+        out = self._anonymizer.apply_to_messages(messages, disabled_classes=disabled)
+        if custom:
+            out = [_apply_custom_rules_to_message(m, custom) for m in out]
+        return out
+
+    def _fetch_rules_state(self):
+        """Return (disabled_classes, custom_rules). Updates ``_last_anonymization_version``.
+
+        When ``RulesClient`` is not configured returns empty values and leaves
+        ``_last_anonymization_version`` as None (no stamp on payload).
+        """
+        if self._rules_client is None:
+            self._last_anonymization_version = None
+            return set(), []
+        rules_doc = self._rules_client.get()  # may raise MonkAIAnonymizerNotReady
+        rules = rules_doc.get("rules", {})
+        toggles = rules.get("toggles", {}) or {}
+        disabled = {name for name, enabled in toggles.items() if enabled is False}
+        custom = rules.get("custom") or []
+        self._last_anonymization_version = int(rules_doc.get("version", 0))
+        return disabled, custom
 
     def _serialize_record(self, record: ConversationRecord) -> Dict:
         """Serialize a record and anonymize its message content before transmission."""
         payload = record.to_api_format()
         if "msg" in payload and payload["msg"] is not None:
             payload["msg"] = self._anonymize_messages(payload["msg"])
+        if self._last_anonymization_version is not None:
+            payload["anonymization_version"] = self._last_anonymization_version
         return payload
 
     def _check_dedup_response(self, response_dict: Dict, total_records: int) -> Dict:

--- a/monkai_trace/exceptions.py
+++ b/monkai_trace/exceptions.py
@@ -31,6 +31,17 @@ class MonkAIAPIError(MonkAIError):
     pass
 
 
+class MonkAIAnonymizerNotReady(MonkAIError):
+    """Raised when custom anonymization rules are required but unavailable.
+
+    This is raised by the upload pipeline when ``RulesClient.get()`` has never
+    succeeded — sending the payload would mean transmitting raw content that
+    only the baseline rules touched. We block to avoid leaking PII the tenant
+    expects to be redacted by their custom rules.
+    """
+    pass
+
+
 class MonkAIRecordDiscardedError(MonkAIAPIError):
     """Raised in strict_dedup mode when the server reports records were deduplicated.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.4.0"
+version = "0.5.0"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_client_custom_rules.py
+++ b/tests/test_client_custom_rules.py
@@ -1,0 +1,251 @@
+"""End-to-end tests for the SDK applying custom rules + stamping version.
+
+Covers both the sync ``MonkAIClient`` and the async ``AsyncMonkAIClient``,
+exercising:
+  * version stamp lands on the outbound payload as ``anonymization_version``.
+  * custom rules redact text after the baseline runs.
+  * baseline toggles disable specific classes (``toggles[name] = false``).
+  * upload is blocked when ``RulesClient`` cannot be fetched and has no cache.
+  * client without ``rules_url`` keeps Phase-1 behaviour (no version stamped,
+    no custom rules applied).
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monkai_trace import AsyncMonkAIClient, MonkAIClient
+from monkai_trace.anonymizer.rules_client import RulesClient
+from monkai_trace.exceptions import MonkAIAnonymizerNotReady
+
+
+def _seed_rules(client, version, toggles=None, custom=None):
+    """Seed the client's RulesClient cache so no network call is made."""
+    rc = client._rules_client
+    rc._cache = {
+        "version": version,
+        "rules": {
+            "toggles": toggles or {},
+            "custom": custom or [],
+        },
+    }
+    rc._cached_at = 1e12  # far future
+
+
+def _capture_post(captured):
+    def fake(method, url, json=None, **kwargs):
+        if json is not None:
+            captured.append(json)
+        resp = MagicMock()
+        resp.status_code = 201
+        resp.reason = "Created"
+        resp.json.return_value = {"inserted_count": 1}
+        return resp
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Sync client
+# ---------------------------------------------------------------------------
+
+
+def test_sync_stamps_anonymization_version_on_payload():
+    client = MonkAIClient(tracer_token="tk_test", rules_url="http://hub")
+    _seed_rules(client, version=7)
+    captured = []
+
+    with patch("requests.Session.request", side_effect=_capture_post(captured)):
+        client.upload_record(
+            namespace="t", agent="bot",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert len(captured) == 1
+    record = captured[0]["records"][0]
+    assert record["anonymization_version"] == 7
+
+
+def test_sync_applies_custom_rule_on_top_of_baseline():
+    client = MonkAIClient(tracer_token="tk_test", rules_url="http://hub")
+    _seed_rules(
+        client,
+        version=2,
+        custom=[{"name": "mk_id", "pattern": r"MK-\d+", "replacement": "[MK_ID]"}],
+    )
+    captured = []
+
+    with patch("requests.Session.request", side_effect=_capture_post(captured)):
+        client.upload_record(
+            namespace="t", agent="bot",
+            messages=[{"role": "user", "content": "id MK-12345 user@m.com"}],
+        )
+
+    body = json.dumps(captured[0])
+    assert "MK-12345" not in body
+    assert "[MK_ID]" in body
+    # Baseline still runs first
+    assert "user@m.com" not in body
+    assert "[EMAIL]" in body
+
+
+def test_sync_toggle_disables_baseline_class():
+    client = MonkAIClient(tracer_token="tk_test", rules_url="http://hub")
+    # email toggle off → email should NOT be redacted
+    _seed_rules(client, version=4, toggles={"email": False})
+    captured = []
+
+    with patch("requests.Session.request", side_effect=_capture_post(captured)):
+        client.upload_record(
+            namespace="t", agent="bot",
+            messages=[{"role": "user", "content": "arthur@monkai.com.br + cpf 123.456.789-09"}],
+        )
+
+    body = json.dumps(captured[0])
+    assert "arthur@monkai.com.br" in body, "email toggle was off — email should pass through"
+    # CPF not toggled → still redacted
+    assert "[CPF]" in body
+
+
+def test_sync_blocks_upload_when_rules_unavailable():
+    client = MonkAIClient(tracer_token="tk_test", rules_url="http://hub")
+    # Force RulesClient.get to fail with no cache
+    with patch(
+        "monkai_trace.anonymizer.rules_client.requests.get",
+        side_effect=RuntimeError("hub down"),
+    ):
+        with pytest.raises(MonkAIAnonymizerNotReady):
+            client.upload_record(
+                namespace="t", agent="bot",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+
+def test_sync_without_rules_url_preserves_phase1_behaviour():
+    """No rules_url → no version stamp, baseline still applies."""
+    client = MonkAIClient(tracer_token="tk_test")
+    captured = []
+
+    with patch("requests.Session.request", side_effect=_capture_post(captured)):
+        client.upload_record(
+            namespace="t", agent="bot",
+            messages=[{"role": "user", "content": "cpf 123.456.789-09"}],
+        )
+
+    record = captured[0]["records"][0]
+    assert "anonymization_version" not in record
+    assert "[CPF]" in json.dumps(record)
+
+
+# ---------------------------------------------------------------------------
+# Async client
+# ---------------------------------------------------------------------------
+
+
+def _async_capture_request():
+    captured = []
+
+    class _Resp:
+        def __init__(self, status=201, payload=None):
+            self.status = status
+            self._payload = payload or {"inserted_count": 1}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        def raise_for_status(self):
+            if self.status >= 400:
+                raise RuntimeError(f"http {self.status}")
+
+        async def json(self):
+            return self._payload
+
+    def fake_request(method, url, json=None, **kwargs):
+        if json is not None:
+            captured.append(json)
+        return _Resp()
+
+    return captured, fake_request
+
+
+def test_async_stamps_version_and_applies_custom_rule():
+    async def run():
+        client = AsyncMonkAIClient(tracer_token="tk_test", rules_url="http://hub")
+        _seed_rules(
+            client,
+            version=11,
+            custom=[{"name": "mk_id", "pattern": r"MK-\d+", "replacement": "[MK_ID]"}],
+        )
+        captured, fake = _async_capture_request()
+        with patch("aiohttp.ClientSession.request", side_effect=fake):
+            await client.upload_record(
+                namespace="t", agent="bot",
+                messages=[{"role": "user", "content": "id MK-99 user@m.com"}],
+            )
+        await client.close()
+        return captured
+
+    captured = asyncio.run(run())
+    body = json.dumps(captured[0])
+    assert "MK-99" not in body
+    assert "[MK_ID]" in body
+    assert "[EMAIL]" in body
+    assert captured[0]["records"][0]["anonymization_version"] == 11
+
+
+def test_async_blocks_when_rules_unavailable():
+    async def run():
+        client = AsyncMonkAIClient(tracer_token="tk_test", rules_url="http://hub")
+        with patch(
+            "monkai_trace.anonymizer.rules_client.requests.get",
+            side_effect=RuntimeError("hub down"),
+        ):
+            with pytest.raises(MonkAIAnonymizerNotReady):
+                await client.upload_record(
+                    namespace="t", agent="bot",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_async_without_rules_url_preserves_phase1_behaviour():
+    async def run():
+        client = AsyncMonkAIClient(tracer_token="tk_test")
+        captured, fake = _async_capture_request()
+        with patch("aiohttp.ClientSession.request", side_effect=fake):
+            await client.upload_record(
+                namespace="t", agent="bot",
+                messages=[{"role": "user", "content": "cpf 123.456.789-09"}],
+            )
+        await client.close()
+        return captured
+
+    captured = asyncio.run(run())
+    record = captured[0]["records"][0]
+    assert "anonymization_version" not in record
+    assert "[CPF]" in json.dumps(record)
+
+
+def test_external_rules_client_injection():
+    """User can pass a pre-built RulesClient (e.g. shared across multiple clients)."""
+    rc = RulesClient(tracer_token="tk_test", hub_url="http://hub", ttl_seconds=300)
+    rc._cache = {
+        "version": 42,
+        "rules": {"toggles": {}, "custom": []},
+    }
+    rc._cached_at = 1e12
+
+    client = MonkAIClient(tracer_token="tk_test", rules_client=rc)
+    captured = []
+    with patch("requests.Session.request", side_effect=_capture_post(captured)):
+        client.upload_record(
+            namespace="t", agent="bot",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    assert captured[0]["records"][0]["anonymization_version"] == 42

--- a/tests/test_rules_client.py
+++ b/tests/test_rules_client.py
@@ -1,0 +1,118 @@
+"""Tests for ``monkai_trace.anonymizer.rules_client.RulesClient``.
+
+The RulesClient fetches per-tenant anonymization rules from the Hub edge
+function and caches them with a TTL. Failure modes:
+  * never-succeeded → raises ``MonkAIAnonymizerNotReady`` so the upload
+    pipeline can block.
+  * succeeded once, then transient failure → returns stale cache and warns.
+  * cache hit within TTL → no network call.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monkai_trace.anonymizer.rules_client import RulesClient
+from monkai_trace.exceptions import MonkAIAnonymizerNotReady
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def test_get_fetches_and_caches_within_ttl():
+    payload = {"version": 3, "rules": {"toggles": {"email": True}, "custom": []}}
+    with patch("monkai_trace.anonymizer.rules_client.requests.get") as g:
+        g.return_value = _ok_response(payload)
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=300)
+        a = c.get()
+        b = c.get()
+    assert a == b
+    assert a["version"] == 3
+    assert g.call_count == 1, "Second call within TTL must hit cache, not network"
+
+
+def test_get_refetches_after_ttl_expires():
+    with patch("monkai_trace.anonymizer.rules_client.requests.get") as g:
+        g.return_value = _ok_response(
+            {"version": 1, "rules": {"toggles": {}, "custom": []}}
+        )
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=0)
+        c.get()
+        # second call: TTL=0 forces refetch
+        g.return_value = _ok_response(
+            {"version": 2, "rules": {"toggles": {}, "custom": []}}
+        )
+        result = c.get()
+    assert result["version"] == 2
+    assert g.call_count == 2
+
+
+def test_get_blocks_when_never_fetched_and_failing():
+    with patch(
+        "monkai_trace.anonymizer.rules_client.requests.get",
+        side_effect=RuntimeError("hub down"),
+    ):
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=300)
+        with pytest.raises(MonkAIAnonymizerNotReady):
+            c.get()
+
+
+def test_get_returns_stale_cache_on_failure_after_first_success(caplog):
+    with patch("monkai_trace.anonymizer.rules_client.requests.get") as g:
+        g.return_value = _ok_response(
+            {"version": 7, "rules": {"toggles": {}, "custom": []}}
+        )
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=0)
+        first = c.get()
+        assert first["version"] == 7
+        # Now make the next fetch fail; cache must still serve.
+        g.side_effect = RuntimeError("hub flapping")
+        with caplog.at_level("WARNING"):
+            second = c.get()
+    assert second["version"] == 7
+    assert any("stale cache" in r.message for r in caplog.records)
+
+
+def test_invalidate_forces_refetch():
+    with patch("monkai_trace.anonymizer.rules_client.requests.get") as g:
+        g.return_value = _ok_response(
+            {"version": 1, "rules": {"toggles": {}, "custom": []}}
+        )
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=300)
+        c.get()
+        c.invalidate()
+        c.get()
+    assert g.call_count == 2
+
+
+def test_normalize_handles_missing_fields():
+    with patch("monkai_trace.anonymizer.rules_client.requests.get") as g:
+        g.return_value = _ok_response({"foo": "bar"})  # garbage
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=300)
+        result = c.get()
+    assert result == {
+        "version": 0,
+        "rules": {"toggles": {}, "custom": []},
+    }
+
+
+def test_endpoint_strips_trailing_slash():
+    c = RulesClient(tracer_token="tk_x", hub_url="http://h/", ttl_seconds=300)
+    assert c.endpoint == "http://h/v1/anonymization-rules"
+
+
+def test_get_async_runs_blocking_fetch_in_thread():
+    import asyncio
+
+    payload = {"version": 5, "rules": {"toggles": {}, "custom": []}}
+    with patch("monkai_trace.anonymizer.rules_client.requests.get") as g:
+        g.return_value = _ok_response(payload)
+        c = RulesClient(tracer_token="tk_x", hub_url="http://h", ttl_seconds=300)
+        result = asyncio.run(c.get_async())
+    assert result["version"] == 5


### PR DESCRIPTION
## O que foi feito

- `monkai_trace/anonymizer/rules_client.py` (novo) — `RulesClient` busca `GET /v1/anonymization-rules` no Hub, mantém cache em memória com TTL (default 300s), serve cache stale com warning em falhas transientes e bloqueia upload via `MonkAIAnonymizerNotReady` quando nunca conseguiu fetch.
- `BaselineAnonymizer` ganha argumento opcional `disabled_classes` para respeitar `toggles[<class>] = false` do documento de rules.
- `MonkAIClient` e `AsyncMonkAIClient` ganham parâmetros opt-in `rules_url=` (ou `rules_client=` para injeção) — quando setado, o pipeline aplica baseline → custom rules e estampa `anonymization_version=N` no payload de saída. Default preserva comportamento Phase 1.
- `MonkAIAnonymizerNotReady` adicionada à hierarquia de exceções e exposta no `__init__`.
- Versão bumpada para `0.5.0` (minor — feature aditiva, compat preservada).
- CHANGELOG entry.

## Por que

Phase 1 (PRs #2 + #7) entregou baseline hardcoded. Esta PR fecha a issue #8 dando ao admin do Hub o controle de regras (toggles + custom regex) sem precisar de release do SDK. O `anonymization_version` no payload permite o edge function detectar drift e re-aplicar regras server-side (Task 4 do plano).

A Phase 2 do Hub (`BeMonkAI/monkai-agent-hub`) está sendo desenvolvida em paralelo — esta PR pode mergear primeiro porque o comportamento default (`rules_url=None`) é o mesmo de 0.4.0.

## Como testar

1. `pytest tests/test_rules_client.py tests/test_client_custom_rules.py -v` — 16 casos cobrindo cache hit/expired/stale, block on never-fetched, custom rule aplicada pos-baseline, toggle desabilita classe, version stamp, sync e async, injeção de `RulesClient` externo.
2. Smoke contra mock do endpoint:
   ```python
   from monkai_trace import MonkAIClient
   c = MonkAIClient(tracer_token="tk_x", rules_url="http://localhost:54321/functions/v1/monkai-api")
   c.upload_record(namespace="t", agent="b", messages=[{"role":"user","content":"id MK-12345"}])
   # Esperado no payload: anonymization_version setado + "[MK_ID]" se a custom rule MK-\d+ existir
   ```

## Definition of done (issue #8)

- [x] RulesClient com cache + TTL + fallback
- [x] Custom rules aplicadas pos-baseline
- [x] Toggles de baseline classes respeitados
- [x] `anonymization_version` no payload
- [x] Block upload quando rules nao disponiveis (vs mandar raw)
- [x] Tests cobrindo todos os cenarios (16 casos)
- [x] CHANGELOG entry
- [x] Release bumpando minor (0.4.0 → 0.5.0); compat Phase 1 mantida

## Checklist

- [x] Testes passando (`pytest tests/test_rules_client.py tests/test_client_custom_rules.py tests/test_baseline_anonymizer.py tests/test_client_anonymization.py tests/test_client.py`: 82 passed)
- [x] Build local OK (módulos importam, `__version__ == "0.5.0"`)
- [x] Documentação atualizada (CHANGELOG)
- [ ] Publicar no PyPI / Azure Artifacts após merge

Closes #8