### PR TITLE
docs(api): Quick Wins — status codes, Node.js example, .http collection

### DIFF
--- a/docs/http_rest_api.md
+++ b/docs/http_rest_api.md
@@ -339,6 +339,121 @@ Batch upload conversation records.
 
 ---
 
+## Integrate from Node.js (no SDK)
+
+Node.js 18+ has `fetch` natively — no dependencies required.
+
+```javascript
+// monkai-trace.mjs
+const API = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api";
+const TOKEN = process.env.MONKAI_TRACER_TOKEN; // never hard-code
+const NAMESPACE = "my-agent";
+
+const headers = {
+  "tracer_token": TOKEN,
+  "Content-Type": "application/json",
+};
+
+async function post(path, body) {
+  const res = await fetch(`${API}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`MonkAI ${path} → ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export async function traceConversation({ phone, name, userMsg, botResponse }) {
+  // 1. Get or create the session for this user (recommended for HTTP clients
+  //    in stateless environments — keeps the session alive across requests
+  //    based on inactivity_timeout).
+  const session = await post("/sessions/get-or-create", {
+    namespace: NAMESPACE,
+    user_id: phone,
+    inactivity_timeout: 300,
+  });
+
+  // 2. Trace the LLM call.
+  await post("/traces/llm", {
+    session_id: session.session_id,
+    model: "gpt-4",
+    provider: "openai",
+    input: { messages: [{ role: "user", content: userMsg }] },
+    output: { content: botResponse },
+    external_user_id: phone,
+    external_user_name: name,
+    external_user_channel: "whatsapp",
+  });
+
+  // 3. (Optional) Trace a tool call.
+  await post("/traces/tool", {
+    session_id: session.session_id,
+    tool_name: "get_fuel_price",
+    arguments: { fuel_type: "gasoline", city: "São Paulo" },
+    result: { price: 5.89, currency: "BRL" },
+    latency_ms: 120,
+    agent: "fuel-assistant",
+    external_user_id: phone,
+    external_user_name: name,
+    external_user_channel: "whatsapp",
+  });
+}
+
+// Usage:
+//   MONKAI_TRACER_TOKEN=tk_xxx node monkai-trace.mjs
+await traceConversation({
+  phone: "5521999998888",
+  name: "Italo",
+  userMsg: "Qual o preço da gasolina?",
+  botResponse: "O preço atual da gasolina é R$ 5,89/L.",
+});
+```
+
+### Retry with backoff (production-ready)
+
+```javascript
+async function postWithRetry(path, body, { maxAttempts = 3 } = {}) {
+  let lastErr;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await post(path, body);
+    } catch (err) {
+      lastErr = err;
+      // Only retry on transient errors (5xx / 429 / network).
+      const status = Number((err.message.match(/→ (\d+)/) || [])[1] || 0);
+      const transient = status >= 500 || status === 429 || status === 0;
+      if (!transient || attempt === maxAttempts) throw err;
+      const delayMs = 250 * 2 ** (attempt - 1); // 250, 500, 1000 ms
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+  throw lastErr;
+}
+```
+
+### TypeScript types from the OpenAPI spec
+
+If you want strict typing in TS:
+
+```bash
+npx openapi-typescript@7 \
+  https://raw.githubusercontent.com/BeMonkAI/monkai-trace/main/docs/openapi.yaml \
+  -o ./monkai-trace.d.ts
+```
+
+Then:
+
+```typescript
+import type { paths } from "./monkai-trace.d.ts";
+type LlmTrace = paths["/traces/llm"]["post"]["requestBody"]["content"]["application/json"];
+```
+
+---
+
 ## WhatsApp Integration Example
 
 Here's a complete example for integrating with WhatsApp:
@@ -403,8 +518,40 @@ All endpoints return standard error responses:
 }
 ```
 
-Common HTTP status codes:
-- `400` - Bad Request (missing required fields)
-- `401` - Unauthorized (invalid or missing token)
-- `403` - Forbidden (token doesn't have access)
-- `500` - Internal Server Error
+### HTTP Status Codes by Endpoint
+
+Every endpoint may return any of the codes below. Use this table to decide
+how to handle each response programmatically.
+
+| Code | Meaning | When it happens | Retry? |
+|------|---------|-----------------|--------|
+| `200` | OK | Request succeeded; payload is in the response body | — |
+| `400` | Bad Request | Required field missing, invalid JSON, type mismatch, body too large | ❌ Fix payload first |
+| `401` | Unauthorized | `tracer_token` header missing or invalid | ❌ Refresh token |
+| `403` | Forbidden | Token is valid but does not have access to that namespace/resource | ❌ Check permissions |
+| `429` | Too Many Requests | Rate limit hit (planned in Phase 3 of API roadmap) | ✅ Backoff + retry |
+| `500` | Internal Server Error | Backend bug or transient failure | ✅ Backoff + retry (max 3) |
+| `502` / `503` / `504` | Gateway / Upstream | Edge function or upstream temporarily unavailable | ✅ Backoff + retry (max 3) |
+
+### Retry Guidance
+
+- **Permanent errors (4xx except 429)** — fix the request, do not retry blindly.
+- **Transient errors (429, 5xx)** — exponential backoff, ~3 attempts max.
+- **Idempotency** — most endpoints are NOT yet idempotent (Phase 3 introduces
+  `Idempotency-Key`). For retries today, prefer reusing the same `session_id`
+  and let server-side dedup on `/records/upload` handle duplicates.
+
+### Per-Endpoint Notes
+
+| Endpoint | Common 4xx triggers |
+|---|---|
+| `POST /sessions/create` | `400` if `namespace` missing |
+| `POST /sessions/get-or-create` | `400` if `namespace` or `user_id` missing |
+| `POST /traces/llm` | `400` if `session_id` missing or unknown |
+| `POST /traces/tool` | `400` if `session_id` or `tool_name` missing |
+| `POST /traces/handoff` | `400` if `session_id`, `from_agent`, or `to_agent` missing |
+| `POST /traces/log` | `400` if `message` missing AND neither `session_id` nor `namespace` provided |
+| `POST /records/upload` | `400` if `records` empty or items missing required fields (`namespace`, `agent`, `msg`) |
+| `POST /logs/upload` | `400` if `logs` empty or items missing `namespace`/`level`/`message` |
+| `POST /record_query` `POST /logs/query` | `400` if `namespace` missing |
+| `POST /records/export` `POST /logs/export` | `400` if `namespace` missing or unsupported `format` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,22 @@
 
 This directory contains practical, executable examples demonstrating MonkAI integration patterns.
 
+## REST API (any language)
+
+### 0. `monkai_trace.http` — request collection
+A ready-to-run set of every REST endpoint, usable from VS Code REST Client or
+JetBrains HTTP Client. Edit `@token` at the top, then click "Send Request"
+above any block.
+
+```
+examples/monkai_trace.http
+```
+
+Pairs with `docs/openapi.yaml` (machine-readable contract) and the
+"Integrate from Node.js" section in `docs/http_rest_api.md`.
+
+---
+
 ## Session Management
 
 ### 1. Basic Session Management

--- a/examples/monkai_trace.http
+++ b/examples/monkai_trace.http
@@ -1,0 +1,201 @@
+### MonkAI Trace REST API — request collection
+###
+### Use with the VS Code REST Client extension or JetBrains HTTP Client.
+###
+### 1. Set the variables below (or override via environment files).
+### 2. Click "Send Request" above any block.
+###
+### Spec (machine-readable): ../docs/openapi.yaml
+### Narrative docs:           ../docs/http_rest_api.md
+
+@baseUrl  = https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api
+@token    = tk_REPLACE_ME
+@namespace = my-agent
+@userId   = 5521999998888
+@userName = Italo
+
+### Health note: there is no health endpoint yet (planned for Phase 3).
+### Use the cheapest call (sessions/get-or-create) to smoke-test connectivity.
+
+### 1. Get or create a session  (recommended for stateless HTTP clients)
+# @name session
+POST {{baseUrl}}/sessions/get-or-create
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "namespace": "{{namespace}}",
+  "user_id": "{{userId}}",
+  "inactivity_timeout": 300,
+  "force_new": false
+}
+
+### Capture the session_id from the response above for subsequent calls.
+@sessionId = {{session.response.body.session_id}}
+
+### 2. Force-create a brand new session
+POST {{baseUrl}}/sessions/create
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "namespace": "{{namespace}}",
+  "user_id": "{{userId}}",
+  "inactivity_timeout": 300,
+  "metadata": { "platform": "whatsapp" }
+}
+
+### 3. Trace an LLM call
+POST {{baseUrl}}/traces/llm
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "model": "gpt-4",
+  "provider": "openai",
+  "input": {
+    "messages": [
+      { "role": "user", "content": "Qual o preço da gasolina?" }
+    ]
+  },
+  "output": {
+    "content": "O preço atual da gasolina é R$ 5,89/L.",
+    "usage": { "prompt_tokens": 12, "completion_tokens": 15 }
+  },
+  "latency_ms": 450,
+  "external_user_id": "{{userId}}",
+  "external_user_name": "{{userName}}",
+  "external_user_channel": "whatsapp"
+}
+
+### 4. Trace a tool call
+POST {{baseUrl}}/traces/tool
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "tool_name": "get_fuel_price",
+  "arguments": { "fuel_type": "gasoline", "city": "São Paulo" },
+  "result": { "price": 5.89, "currency": "BRL" },
+  "latency_ms": 120,
+  "agent": "fuel-assistant",
+  "external_user_id": "{{userId}}",
+  "external_user_name": "{{userName}}",
+  "external_user_channel": "whatsapp"
+}
+
+### 5. Trace an agent-to-agent handoff
+POST {{baseUrl}}/traces/handoff
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "from_agent": "triage-agent",
+  "to_agent": "sales-agent",
+  "reason": "Customer wants to purchase fuel",
+  "external_user_id": "{{userId}}",
+  "external_user_name": "{{userName}}",
+  "external_user_channel": "whatsapp"
+}
+
+### 6. Trace a log entry
+POST {{baseUrl}}/traces/log
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "level": "info",
+  "message": "User completed onboarding flow",
+  "metadata": { "step": 5, "duration_ms": 3200 }
+}
+
+### 7. Bulk upload conversation records (Python SDK path)
+POST {{baseUrl}}/records/upload
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "records": [
+    {
+      "namespace": "{{namespace}}",
+      "agent": "support-bot",
+      "session_id": "{{sessionId}}",
+      "msg": [
+        { "role": "user", "content": "Olá" },
+        { "role": "assistant", "content": "Oi, em que posso ajudar?" }
+      ],
+      "input_tokens": 4,
+      "output_tokens": 8,
+      "external_user_id": "{{userId}}",
+      "external_user_name": "{{userName}}",
+      "external_user_channel": "whatsapp",
+      "model": "gpt-4o"
+    }
+  ]
+}
+
+### 8. Bulk upload logs
+POST {{baseUrl}}/logs/upload
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "logs": [
+    {
+      "namespace": "{{namespace}}",
+      "level": "info",
+      "message": "Heartbeat",
+      "resource_id": "worker-1"
+    }
+  ]
+}
+
+### 9. Query records (filter by namespace + session)
+POST {{baseUrl}}/record_query
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "namespace": "{{namespace}}",
+  "query": {
+    "session_id": "{{sessionId}}",
+    "limit": 50,
+    "offset": 0
+  }
+}
+
+### 10. Query logs
+POST {{baseUrl}}/logs/query
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "namespace": "{{namespace}}",
+  "level": "info",
+  "limit": 100,
+  "offset": 0
+}
+
+### 11. Export records (JSON)
+POST {{baseUrl}}/records/export
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "namespace": "{{namespace}}",
+  "format": "json"
+}
+
+### 12. Export logs (CSV)
+POST {{baseUrl}}/logs/export
+tracer_token: {{token}}
+Content-Type: application/json
+
+{
+  "namespace": "{{namespace}}",
+  "format": "csv"
+}


### PR DESCRIPTION
## O que foi feito

Três dos quatro Quick Wins do roadmap da REST API ([#14](https://github.com/BeMonkAI/monkai-trace/issues/14)):

### 1. Tabela de HTTP Status Codes por endpoint (`docs/http_rest_api.md`)
- Códigos: \`200\`, \`400\`, \`401\`, \`403\`, \`429\`, \`500\`, \`502/503/504\`
- Coluna **\"Retry?\"** indicando o que é seguro repetir
- Tabela secundária com **gatilhos de 4xx por endpoint** (campo obrigatório que faltou em cada path)
- Seção **Retry Guidance** com regra prática (4xx permanente vs. 5xx/429 transiente)

### 2. Seção \"Integrate from Node.js (no SDK)\" (`docs/http_rest_api.md`)
- Exemplo completo Node 18+ com \`fetch\` nativo (sem dependências)
- Cobre: get-or-create session, trace LLM, trace tool
- Helper \`postWithRetry()\` com backoff exponencial filtrando códigos transientes
- Snippet pra gerar tipos TS estritos via \`openapi-typescript\` apontando direto pro spec no GitHub

### 3. `examples/monkai_trace.http` — REST Client collection
- 12 requests prontos pra rodar (VS Code REST Client / JetBrains HTTP Client)
- Variáveis no topo: \`@baseUrl\`, \`@token\`, \`@namespace\`, \`@userId\`, \`@userName\`
- Captura automática do \`session_id\` da response 1 pra reutilizar nas próximas
- Linkado em \`examples/README.md\`

### 4. ~~request_id em response~~ → split em [#16](https://github.com/BeMonkAI/monkai-trace/issues/16)
Esse item é server-side (precisa alterar a edge function Supabase). Issue dedicada criada e adicionada ao board.

## Por que

São melhorias baratas (zero código de produção) que destravam **muita** dor para devs integrando hoje:
- **Status codes documentados** → cliente sabe quando faz retry sem precisar adivinhar
- **Node.js example** → primeira porta de entrada pra qualquer integração não-Python
- **.http collection** → qualquer dev manda o primeiro request em < 30s sem precisar montar curl à mão

## Como testar

```bash
# Abrir docs/http_rest_api.md no preview de markdown e validar a tabela
# Abrir examples/monkai_trace.http no VS Code (com REST Client extension)
#   → preencher @token e clicar \"Send Request\" no bloco 1
#   → ver session_id capturado e usar nos blocos seguintes
```

## Checklist

- [x] Mudança é só docs/exemplos — zero impacto em código de produção
- [x] Tabela de status codes consistente com o que o spec OpenAPI já declara (400/401/403/500)
- [x] Node.js example testável copy-paste (Node 18+, sem npm install)
- [x] .http collection cobre os 12 endpoints
- [x] Item 1 (request_id) **não silenciado** — issue [#16](https://github.com/BeMonkAI/monkai-trace/issues/16) aberta e no board
- [x] CI: nenhum workflow quebra (mudança não toca código Python nem spec)

## Referências

- Closes (parcial) #14
- Refs #16 (server-side, deferido)