### PR TITLE
docs(api): promote /v1/ server entry as primary in OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -27,8 +27,10 @@ info:
     url: https://github.com/BeMonkAI/monkai-trace/blob/main/LICENSE
 
 servers:
+  - url: https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1
+    description: Production — versioned routes (recommended for new clients)
   - url: https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api
-    description: Production (current — Supabase edge function)
+    description: Production — legacy unversioned routes (still supported)
   - url: https://api.monkai.ai/trace/v1
     description: Production (planned custom domain — Phase 2)
 


### PR DESCRIPTION
## O que foi feito

Atualiza \`docs/openapi.yaml\` adicionando o servidor versionado como entrada **primária**:

\`\`\`yaml
servers:
  - url: https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1
    description: Production — versioned routes (recommended for new clients)
  - url: https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api
    description: Production — legacy unversioned routes (still supported)
  - url: https://api.monkai.ai/trace/v1
    description: Production (planned custom domain — Phase 2)
\`\`\`

## Por que

Companion de [BeMonkAI/monkai-agent-hub#16](https://github.com/BeMonkAI/monkai-agent-hub/pull/16) (mergeado), que fez a edge function aceitar \`/v1/\` em paralelo às rotas legadas. Com essa mudança no spec:

- Clients gerados via \`openapi-generator\` ou \`openapi-typescript\` adotam \`/v1/\` por default
- Documentação Swagger UI passa a sugerir \`/v1/\` na lista de servers
- Clientes existentes (Python SDK, qualquer cliente que pin no URL legado) continuam funcionando

## Como testar

\`\`\`bash
.venv/bin/python -c \"from openapi_spec_validator import validate; import yaml; validate(yaml.safe_load(open('docs/openapi.yaml'))); print('OK')\"
npx --yes @redocly/cli@latest lint docs/openapi.yaml
\`\`\`

## Checklist

- [x] OpenAPI 3.1 valido
- [x] Redocly lint passa
- [x] Mudança 100% docs (zero código), zero impacto em clientes existentes
- [x] Refletindo edge function ja mergeada em monkai-agent-hub#16

Refs #11