### PR TITLE
docs(api): promote Bearer auth as primary + document X-Request-ID

### DIFF
--- a/docs/http_rest_api.md
+++ b/docs/http_rest_api.md
@@ -10,15 +10,51 @@ The MonkAI Trace HTTP REST API provides a language-agnostic way to send traces f
 ## Base URL
 
 ```
-https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api
+https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1   ← recommended (versioned)
+https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api      ← legacy (still supported)
 ```
+
+The `/v1/` prefix is the contract pin: future breaking changes will land
+under `/v2/` while `/v1/` keeps working. New integrations should use it;
+existing clients without the prefix continue to function.
 
 ## Authentication
 
-All requests require a `tracer_token` header with your MonkAI tracer token.
+Two schemes are accepted, interchangeably:
 
 ```bash
-curl -H "tracer_token: YOUR_TOKEN_HERE" ...
+# Recommended: RFC 6750 bearer auth (works out of the box with curl,
+# fetch, generated clients, and most API gateways).
+curl -H "Authorization: Bearer tk_YOUR_TOKEN" ...
+
+# Legacy: custom header, still supported.
+curl -H "tracer_token: tk_YOUR_TOKEN" ...
+```
+
+Tokens always have the `tk_` prefix. When both headers are sent, the
+legacy `tracer_token` header wins (deterministic during the deprecation
+window). New integrations should prefer `Authorization: Bearer`.
+
+## Request Correlation — `X-Request-ID`
+
+Every response carries an `X-Request-ID` header:
+
+- If the client sends `X-Request-ID: <id>` in the request, it is
+  preserved in the response (round-trip). Useful for distributed
+  traces across multiple services.
+- Otherwise, the server generates a UUIDv4 and returns it.
+
+Always log the `X-Request-ID` you receive on errors. Quote it when
+reporting issues to support — it lets us pinpoint the exact request
+in server logs.
+
+```bash
+curl -i -H "Authorization: Bearer tk_YOUR_TOKEN" \
+     -H "X-Request-ID: my-trace-1" \
+     -X POST .../v1/sessions/get-or-create -d '{...}'
+
+# Response includes:
+#   x-request-id: my-trace-1
 ```
 
 ## User Identification
@@ -45,8 +81,9 @@ These fields enable:
 Creates a new session for tracking a conversation flow.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 - `Content-Type`: `application/json`
+- `X-Request-ID` *(optional)*: client-supplied trace ID, returned round-trip
 
 **Body:**
 | Field | Type | Required | Description |
@@ -70,8 +107,8 @@ Creates a new session for tracking a conversation flow.
 
 **Example:**
 ```bash
-curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/sessions/create \
-  -H "tracer_token: YOUR_TOKEN_HERE" \
+curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/sessions/create \
+  -H "Authorization: Bearer tk_YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "namespace": "my-agent",
@@ -88,8 +125,9 @@ curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/se
 Records an LLM (Large Language Model) call trace.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 - `Content-Type`: `application/json`
+- `X-Request-ID` *(optional)*: client-supplied trace ID, returned round-trip
 
 **Body:**
 | Field | Type | Required | Description |
@@ -117,8 +155,8 @@ Records an LLM (Large Language Model) call trace.
 
 **Example (with user identification):**
 ```bash
-curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/traces/llm \
-  -H "tracer_token: YOUR_TOKEN_HERE" \
+curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/llm \
+  -H "Authorization: Bearer tk_YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "my-agent-5521999998888-20251210123456",
@@ -147,8 +185,9 @@ curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/tr
 Records a tool/function call trace.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 - `Content-Type`: `application/json`
+- `X-Request-ID` *(optional)*: client-supplied trace ID, returned round-trip
 
 **Body:**
 | Field | Type | Required | Description |
@@ -176,8 +215,8 @@ Records a tool/function call trace.
 
 **Example:**
 ```bash
-curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/traces/tool \
-  -H "tracer_token: YOUR_TOKEN_HERE" \
+curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/tool \
+  -H "Authorization: Bearer tk_YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "my-agent-5521999998888-20251210123456",
@@ -199,8 +238,9 @@ curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/tr
 Records an agent-to-agent handoff trace.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 - `Content-Type`: `application/json`
+- `X-Request-ID` *(optional)*: client-supplied trace ID, returned round-trip
 
 **Body:**
 | Field | Type | Required | Description |
@@ -227,8 +267,8 @@ Records an agent-to-agent handoff trace.
 
 **Example:**
 ```bash
-curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/traces/handoff \
-  -H "tracer_token: YOUR_TOKEN_HERE" \
+curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/handoff \
+  -H "Authorization: Bearer tk_YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "my-agent-5521999998888-20251210123456",
@@ -248,8 +288,9 @@ curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/tr
 Records a log entry trace.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 - `Content-Type`: `application/json`
+- `X-Request-ID` *(optional)*: client-supplied trace ID, returned round-trip
 
 **Body:**
 | Field | Type | Required | Description |
@@ -272,8 +313,8 @@ Records a log entry trace.
 
 **Example:**
 ```bash
-curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/traces/log \
-  -H "tracer_token: YOUR_TOKEN_HERE" \
+curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/log \
+  -H "Authorization: Bearer tk_YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "session_id": "my-agent-user123-20251210123456",
@@ -292,7 +333,7 @@ curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/tr
 Batch upload operational logs.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 
 **Body:**
 ```json
@@ -315,7 +356,7 @@ Batch upload operational logs.
 Batch upload conversation records.
 
 **Headers:**
-- `tracer_token`: required
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
 
 **Body:**
 ```json
@@ -345,12 +386,12 @@ Node.js 18+ has `fetch` natively — no dependencies required.
 
 ```javascript
 // monkai-trace.mjs
-const API = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api";
-const TOKEN = process.env.MONKAI_TRACER_TOKEN; // never hard-code
+const API = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1";
+const TOKEN = process.env.MONKAI_TRACER_TOKEN; // never hard-code (must start with "tk_")
 const NAMESPACE = "my-agent";
 
 const headers = {
-  "tracer_token": TOKEN,
+  "Authorization": `Bearer ${TOKEN}`,
   "Content-Type": "application/json",
 };
 
@@ -461,9 +502,10 @@ Here's a complete example for integrating with WhatsApp:
 ```python
 import requests
 
-MONKAI_API = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api"
+MONKAI_API = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1"
 TRACER_TOKEN = "tk_your_token_here"
 NAMESPACE = "trackfuel"
+HEADERS = {"Authorization": f"Bearer {TRACER_TOKEN}", "Content-Type": "application/json"}
 
 def process_whatsapp_message(phone: str, name: str, user_msg: str, bot_response: str):
     """Process and trace a WhatsApp message."""
@@ -471,7 +513,7 @@ def process_whatsapp_message(phone: str, name: str, user_msg: str, bot_response:
     # 1. Create session with user's phone as ID
     session = requests.post(
         f"{MONKAI_API}/sessions/create",
-        headers={"tracer_token": TRACER_TOKEN, "Content-Type": "application/json"},
+        headers=HEADERS,
         json={
             "namespace": NAMESPACE,
             "user_id": phone,
@@ -482,7 +524,7 @@ def process_whatsapp_message(phone: str, name: str, user_msg: str, bot_response:
     # 2. Trace the LLM call with full user identification
     requests.post(
         f"{MONKAI_API}/traces/llm",
-        headers={"tracer_token": TRACER_TOKEN, "Content-Type": "application/json"},
+        headers=HEADERS,
         json={
             "session_id": session["session_id"],
             "model": "gpt-4",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -49,8 +49,8 @@ tags:
     description: Bulk export with server-side pagination.
 
 security:
-  - tracerTokenHeader: []
   - bearerAuth: []
+  - tracerTokenHeader: []
 
 paths:
   # ============================================================
@@ -64,6 +64,8 @@ paths:
         Creates a new session for tracking a conversation flow. Use this when
         you want to force a fresh session, regardless of recent activity.
       operationId: createSession
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -82,6 +84,9 @@ paths:
       responses:
         "200":
           description: Session created
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -105,6 +110,8 @@ paths:
         new one. This is the endpoint used by the Python SDK to keep session
         continuity across stateless environments (REST APIs, serverless).
       operationId: getOrCreateSession
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -114,6 +121,9 @@ paths:
       responses:
         "200":
           description: Session returned (existing or new)
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -135,6 +145,8 @@ paths:
       tags: [Traces]
       summary: Trace an LLM call
       operationId: traceLlmCall
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -144,6 +156,9 @@ paths:
       responses:
         "200":
           description: Trace recorded
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -162,6 +177,8 @@ paths:
       tags: [Traces]
       summary: Trace a tool/function call
       operationId: traceToolCall
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -171,6 +188,9 @@ paths:
       responses:
         "200":
           description: Trace recorded
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -189,6 +209,8 @@ paths:
       tags: [Traces]
       summary: Trace an agent-to-agent handoff
       operationId: traceHandoff
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -198,6 +220,9 @@ paths:
       responses:
         "200":
           description: Trace recorded
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -218,6 +243,8 @@ paths:
       description: |
         Records a log entry. Either `session_id` or `namespace` must be provided.
       operationId: traceLog
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -227,6 +254,9 @@ paths:
       responses:
         "200":
           description: Log recorded
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -253,6 +283,8 @@ paths:
         deduplication is applied; the response indicates how many were inserted
         vs. dropped as duplicates.
       operationId: uploadRecords
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -262,6 +294,9 @@ paths:
       responses:
         "200":
           description: Records processed
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -281,6 +316,8 @@ paths:
       summary: Upload operational logs (batch)
       description: Batch upload of structured log entries.
       operationId: uploadLogs
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -290,6 +327,9 @@ paths:
       responses:
         "200":
           description: Logs processed
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -311,6 +351,8 @@ paths:
       tags: [Query]
       summary: Query conversation records
       operationId: queryRecords
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -320,6 +362,9 @@ paths:
       responses:
         "200":
           description: Records matching the query
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -338,6 +383,8 @@ paths:
       tags: [Query]
       summary: Query log entries
       operationId: queryLogs
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -347,6 +394,9 @@ paths:
       responses:
         "200":
           description: Logs matching the query
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -368,6 +418,8 @@ paths:
       tags: [Export]
       summary: Export conversation records (JSON or CSV)
       operationId: exportRecords
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -377,6 +429,9 @@ paths:
       responses:
         "200":
           description: Records exported
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -399,6 +454,8 @@ paths:
       tags: [Export]
       summary: Export logs (JSON or CSV)
       operationId: exportLogs
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
       requestBody:
         required: true
         content:
@@ -408,6 +465,9 @@ paths:
       responses:
         "200":
           description: Logs exported
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
           content:
             application/json:
               schema:
@@ -427,45 +487,83 @@ paths:
 
 components:
   securitySchemes:
-    tracerTokenHeader:
-      type: apiKey
-      in: header
-      name: tracer_token
-      description: |
-        Current authentication scheme. Send the tracer token in the
-        `tracer_token` HTTP header.
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: opaque
       description: |
-        Planned authentication scheme (Phase 2). Send the tracer token as
-        `Authorization: Bearer <token>`. Both schemes will work in parallel
-        during the deprecation window.
+        Recommended authentication scheme. Send the tracer token as
+        `Authorization: Bearer tk_<hex>`. RFC 6750 — works out of the
+        box with `curl`, `fetch`, generated clients, and most API
+        gateways.
+    tracerTokenHeader:
+      type: apiKey
+      in: header
+      name: tracer_token
+      description: |
+        Legacy authentication scheme, still supported. Send the tracer
+        token in the `tracer_token` HTTP header. Both schemes accept
+        the same `tk_<hex>` token and can be used interchangeably.
+        New integrations should prefer `bearerAuth`.
 
-  parameters: {}
+  parameters:
+    RequestIdHeader:
+      name: X-Request-ID
+      in: header
+      required: false
+      schema:
+        type: string
+        maxLength: 128
+        pattern: '^[\x21-\x7E][\x20-\x7E]{0,127}$'
+      description: |
+        Optional client-supplied request correlation ID. If provided,
+        the server preserves the value in the response `X-Request-ID`
+        header (round-trip). If omitted, the server generates a UUIDv4.
+        Useful for distributed traces and support correlation.
+
+  headers:
+    XRequestId:
+      schema:
+        type: string
+      description: |
+        Request correlation ID. Mirrors the value sent in the request
+        `X-Request-ID` header when present, otherwise a server-generated
+        UUIDv4. Always emitted on every response (200, 4xx, 5xx). Quote
+        this value when reporting issues.
 
   responses:
     BadRequest:
       description: Bad Request — required field missing or invalid payload
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
     Unauthorized:
       description: Unauthorized — invalid or missing tracer token
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
     Forbidden:
       description: Forbidden — token does not have access to the resource
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
     InternalError:
       description: Internal Server Error
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestId"
       content:
         application/json:
           schema:

--- a/examples/monkai_trace.http
+++ b/examples/monkai_trace.http
@@ -8,7 +8,7 @@
 ### Spec (machine-readable): ../docs/openapi.yaml
 ### Narrative docs:           ../docs/http_rest_api.md
 
-@baseUrl  = https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api
+@baseUrl  = https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1
 @token    = tk_REPLACE_ME
 @namespace = my-agent
 @userId   = 5521999998888
@@ -20,7 +20,7 @@
 ### 1. Get or create a session  (recommended for stateless HTTP clients)
 # @name session
 POST {{baseUrl}}/sessions/get-or-create
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -35,7 +35,7 @@ Content-Type: application/json
 
 ### 2. Force-create a brand new session
 POST {{baseUrl}}/sessions/create
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -47,7 +47,7 @@ Content-Type: application/json
 
 ### 3. Trace an LLM call
 POST {{baseUrl}}/traces/llm
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -71,7 +71,7 @@ Content-Type: application/json
 
 ### 4. Trace a tool call
 POST {{baseUrl}}/traces/tool
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -88,7 +88,7 @@ Content-Type: application/json
 
 ### 5. Trace an agent-to-agent handoff
 POST {{baseUrl}}/traces/handoff
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -103,7 +103,7 @@ Content-Type: application/json
 
 ### 6. Trace a log entry
 POST {{baseUrl}}/traces/log
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -115,7 +115,7 @@ Content-Type: application/json
 
 ### 7. Bulk upload conversation records (Python SDK path)
 POST {{baseUrl}}/records/upload
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -140,7 +140,7 @@ Content-Type: application/json
 
 ### 8. Bulk upload logs
 POST {{baseUrl}}/logs/upload
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -156,7 +156,7 @@ Content-Type: application/json
 
 ### 9. Query records (filter by namespace + session)
 POST {{baseUrl}}/record_query
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -170,7 +170,7 @@ Content-Type: application/json
 
 ### 10. Query logs
 POST {{baseUrl}}/logs/query
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -182,7 +182,7 @@ Content-Type: application/json
 
 ### 11. Export records (JSON)
 POST {{baseUrl}}/records/export
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {
@@ -192,7 +192,7 @@ Content-Type: application/json
 
 ### 12. Export logs (CSV)
 POST {{baseUrl}}/logs/export
-tracer_token: {{token}}
+Authorization: Bearer {{token}}
 Content-Type: application/json
 
 {


### PR DESCRIPTION
## O que foi feito

Companion docs das PRs server-side já em prod (monkai-api v134, deploy em 2026-05-01):
- [BeMonkAI/monkai-agent-hub#17](https://github.com/BeMonkAI/monkai-agent-hub/pull/17) — Bearer auth
- [BeMonkAI/monkai-agent-hub#18](https://github.com/BeMonkAI/monkai-agent-hub/pull/18) — X-Request-ID

### \`docs/openapi.yaml\`
- **\`bearerAuth\`** agora é o esquema primário (vem antes de \`tracerTokenHeader\` em \`security\`)
- **\`RequestIdHeader\`** novo parameter referenciado por **12 operações** — clients gerados e Swagger UI agora mostram que \`X-Request-ID\` é aceito como header de request
- **\`XRequestId\`** novo header compartilhado em \`#/components/headers/\` referenciado por **12 responses 200** + **4 responses de erro** (BadRequest, Unauthorized, Forbidden, InternalError)
- Descrição do \`tracerTokenHeader\` mudada de \"current scheme\" para \"legacy, still supported\"

### \`docs/http_rest_api.md\`
- Seção **Authentication** reescrita: dois esquemas, precedência documentada
- Nova seção **Request Correlation — \`X-Request-ID\`** explicando round-trip + UUID fallback
- **Todos os curl examples** migrados pra \`Authorization: Bearer\` + \`/v1/\`
- **Todas as \"Headers:\"** lists agora mencionam ambos esquemas + \`X-Request-ID\` opcional
- **Node.js example** usa Bearer + \`/v1/\`
- **Python WhatsApp example** usa Bearer + \`/v1/\` (HEADERS compartilhado)

### \`examples/monkai_trace.http\`
- \`@baseUrl\` agora aponta pra \`/v1/\`
- Todos os 12 requests usam \`Authorization: Bearer {{token}}\`

## Por que

Sem essas atualizações, o spec divergia da realidade em prod:
- Cliente gerado via \`openapi-generator\` colocava \`tracer_token\` como esquema padrão (deveria ser Bearer)
- Devs lendo \`http_rest_api.md\` não sabiam que Bearer funciona, nem que toda response traz \`X-Request-ID\`
- Swagger UI listava \`tracerTokenHeader\` como auth principal

Esse PR fecha o gap entre prod e doc.

## Como testar

\`\`\`bash
# Validação OpenAPI
.venv/bin/python -c \"from openapi_spec_validator import validate; import yaml; validate(yaml.safe_load(open('docs/openapi.yaml')))\"

# Lint
npx --yes @redocly/cli@latest lint docs/openapi.yaml

# Smoke contra prod
curl -i -H \"Authorization: Bearer \$TK_TOKEN\" -H \"X-Request-ID: doc-pr-smoke\" \\
  -X POST -H \"Content-Type: application/json\" -d '{\"namespace\":\"test\",\"user_id\":\"x\"}' \\
  https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/sessions/get-or-create

# Resposta deve incluir: x-request-id: doc-pr-smoke
\`\`\`

## Checklist

- [x] OpenAPI 3.1 valido (\`openapi-spec-validator\` + Redocly, zero warnings)
- [x] Mudança 100% docs (zero código), zero impacto runtime
- [x] Reflete o que está deployado em prod (monkai-api v134)
- [x] CI \`OpenAPI Lint\` workflow vai disparar (path filter \`docs/openapi.yaml\`)

## Segue depois

- **PR 4/4 Fase 2** — error envelope estruturado (toca monkai-hub)
- **Custom domain** (\`api.monkai.ai/trace/v1\`) — Fase 2 ainda
- **Fase 3** — robustez (idempotency, batch, rate limit, health)
- **Fase 4** — site de docs first-class

Refs #11