### PR TITLE
docs(api): Fase 4 — docs site first-class (ReDoc, code samples, migration guide)

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -5,11 +5,13 @@ on:
     branches: [main, develop]
     paths:
       - "docs/openapi.yaml"
+      - "docs/postman_collection.json"
       - ".github/workflows/openapi-lint.yml"
   pull_request:
     branches: [main, develop]
     paths:
       - "docs/openapi.yaml"
+      - "docs/postman_collection.json"
       - ".github/workflows/openapi-lint.yml"
 
 jobs:
@@ -89,3 +91,40 @@ jobs:
           test -d /tmp/monkai-trace-ts/apis
           test -d /tmp/monkai-trace-ts/models
           echo "OK — generator emitted runtime + apis + models"
+
+  postman-collection:
+    name: Postman collection sanity
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Validate committed collection structure
+        run: |
+          # docs/postman_collection.json is generated from docs/openapi.yaml via:
+          #   npx openapi-to-postmanv2 -s docs/openapi.yaml -o docs/postman_collection.json -p -O folderStrategy=Tags
+          # The generator embeds randomly-faked values for free-form fields,
+          # so a strict diff isn't reliable. Instead we sanity-check:
+          #   - file is valid JSON
+          #   - it claims Postman v2.1.0 schema
+          #   - it has at least one folder with at least one request
+          node - <<'JS'
+          const fs = require('fs');
+          const c = JSON.parse(fs.readFileSync('docs/postman_collection.json', 'utf8'));
+          if (!c.info?.schema?.includes('schema.getpostman.com/json/collection/v2.1.0')) {
+            console.error('Not a Postman v2.1.0 collection');
+            process.exit(1);
+          }
+          const folders = c.item || [];
+          const requests = folders.flatMap(f => f.item || []).length;
+          if (folders.length < 1 || requests < 6) {
+            console.error(`Suspicious collection size: ${folders.length} folders / ${requests} requests`);
+            process.exit(1);
+          }
+          console.log(`OK — Postman v2.1.0, ${folders.length} folders, ${requests} requests.`);
+          JS

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Official Python client for [MonkAI](https://monkai.ai) - Monitor, analyze, and o
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
+> 📖 **REST API reference**: [bemonkai.github.io/monkai-trace](https://bemonkai.github.io/monkai-trace/) — interactive ReDoc with curl/Node/Python samples per endpoint
+> · [Migration guide](docs/MIGRATION.md)
+> · [API changelog](docs/API_CHANGELOG.md)
+> · [OpenAPI spec](docs/openapi.yaml)
+> · [Postman collection](docs/postman_collection.json)
+
 ## Features
 
 - **Upload conversation records** with full token segmentation

--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -1,0 +1,61 @@
+# MonkAI Trace REST API — Changelog
+
+This file tracks changes to the **REST API contract** (the surface
+documented in [`openapi.yaml`](./openapi.yaml) and [`http_rest_api.md`](./http_rest_api.md)).
+It is intentionally separate from [`../CHANGELOG.md`](../CHANGELOG.md), which
+tracks the Python SDK package.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The API itself is versioned via the URL prefix (`/v1/`) — breaking
+changes will land under a new prefix (`/v2/`) while older versions
+keep working during a deprecation window.
+
+## [Unreleased]
+
+### Planned (Phase 3)
+- `Idempotency-Key` header for `POST /traces/*` and `POST /v1/traces/batch`.
+- Batch endpoint `POST /v1/traces/batch` for mixed `llm`/`tool`/`handoff`/`log` payloads.
+- Rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
+- `GET /v1/health` health-check endpoint.
+
+### Planned (Phase 2 — remaining)
+- Structured error envelope `{ "error": { "code": "...", "message": "...", "request_id": "..." } }`.
+- Custom domain `https://api.monkai.ai/trace/v1`.
+
+## [v1] — 2026-05-01
+
+First versioned contract. Snapshot of what is currently live in
+production (`monkai-api` edge function on Supabase project
+`lpvbvnqrozlwalnkvrgk`, version 134).
+
+### Added
+- **`/v1/` URL prefix** — every endpoint now also responds under
+  `/functions/v1/monkai-api/v1/<path>`. Unversioned URLs continue to
+  work for backwards compatibility. New integrations should pin to
+  `/v1/`. Reference: [BeMonkAI/monkai-agent-hub#16](https://github.com/BeMonkAI/monkai-agent-hub/pull/16).
+- **`Authorization: Bearer tk_<token>`** auth scheme. The legacy
+  `tracer_token` request header still works; both schemes accept the
+  same `tk_<hex>` token. New integrations should prefer `Bearer`.
+  Reference: [BeMonkAI/monkai-agent-hub#17](https://github.com/BeMonkAI/monkai-agent-hub/pull/17).
+- **`X-Request-ID` response header** on every response (200, 4xx, 5xx).
+  Round-trips when the client sends one; otherwise a UUIDv4 is
+  generated. Useful for support correlation and distributed traces.
+  Reference: [BeMonkAI/monkai-agent-hub#18](https://github.com/BeMonkAI/monkai-agent-hub/pull/18).
+- **OpenAPI 3.1 spec** at [`docs/openapi.yaml`](./openapi.yaml) covering
+  all 12 endpoints. Generates clients via `openapi-typescript`,
+  `openapi-generator`, etc. Browse interactively at
+  [`docs/index.html`](./index.html) (ReDoc).
+- **`.http` collection** at [`examples/monkai_trace.http`](../examples/monkai_trace.http)
+  ready for VS Code REST Client and JetBrains HTTP Client.
+
+### Notes
+- `tracer_token` header **wins** when both `Authorization: Bearer` and
+  `tracer_token` are present on the same request — deterministic during
+  the deprecation window.
+- The bulk endpoints `POST /records/upload` and `POST /logs/upload` are
+  the primary path used by the Python SDK and remain fully supported.
+
+## [pre-v1]
+
+Endpoints existed unversioned before 2026-05-01. They keep working
+indefinitely; treat them as `v1` semantics until further notice.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,173 @@
+# MonkAI Trace REST API — Migration Guide
+
+This guide is for clients integrating with the MonkAI Trace REST API
+(not for the Python SDK — the SDK upgrades are tracked in
+[`../CHANGELOG.md`](../CHANGELOG.md)).
+
+The current contract is **v1** ([API changelog](./API_CHANGELOG.md)).
+Two forward-looking changes happened on 2026-05-01 that are
+**non-breaking** but recommended:
+
+1. URL prefix → `/v1/`
+2. Auth header → `Authorization: Bearer`
+
+Plus a behaviour change you can opt into for free:
+
+3. `X-Request-ID` round-trip for support correlation
+
+---
+
+## 1. URL prefix → `/v1/`
+
+### Before
+
+```
+POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/sessions/create
+```
+
+### After (recommended)
+
+```
+POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/sessions/create
+```
+
+### Why
+
+Pinning to `/v1/` guarantees the contract you integrated against won't
+change under your feet. Future breaking changes will land under `/v2/`,
+and you can opt in when ready. Unversioned URLs keep working
+indefinitely as a `v1` alias, but new integrations should pin.
+
+### How
+
+Search and replace your base URL:
+
+```diff
+- BASE_URL = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api"
++ BASE_URL = "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1"
+```
+
+Generated clients pick this up automatically — the OpenAPI spec lists
+`/v1/` as the primary `servers[0]` entry.
+
+---
+
+## 2. Auth header → `Authorization: Bearer`
+
+### Before
+
+```http
+tracer_token: tk_abc123...
+```
+
+### After (recommended)
+
+```http
+Authorization: Bearer tk_abc123...
+```
+
+### Why
+
+`Authorization: Bearer` is the RFC 6750 standard. Tools, generated
+clients, API gateways, and HTTP libraries support it natively. The
+legacy `tracer_token` custom header sometimes breaks integrations with
+no-code platforms or proxies that strip non-standard headers.
+
+### How
+
+#### curl
+
+```diff
+- curl -H "tracer_token: tk_abc"
++ curl -H "Authorization: Bearer tk_abc"
+```
+
+#### Node.js (fetch)
+
+```diff
+  const headers = {
+-   "tracer_token": process.env.MONKAI_TRACER_TOKEN,
++   "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+    "Content-Type": "application/json",
+  };
+```
+
+#### Python (requests)
+
+```diff
+  headers = {
+-     "tracer_token": TRACER_TOKEN,
++     "Authorization": f"Bearer {TRACER_TOKEN}",
+      "Content-Type": "application/json",
+  }
+```
+
+### Precedence (during the deprecation window)
+
+If a client sends **both** headers, the legacy `tracer_token` wins.
+This is deterministic and lets you migrate one service at a time
+without surprises. We will announce a deprecation date for
+`tracer_token` only after the SDK migration completes — for now it
+continues to work indefinitely.
+
+---
+
+## 3. `X-Request-ID` for support correlation
+
+This is **opt-in** and purely additive — nothing breaks if you ignore
+it. Highly recommended for production integrations.
+
+### Behaviour
+
+- Every response (200, 4xx, 5xx) carries `X-Request-ID: <id>`.
+- If the client sends `X-Request-ID: <id>` in the request, the value
+  is **preserved** in the response (round-trip). This lets you
+  correlate logs across multiple services without coordination.
+- If the client doesn't send one, the server generates a UUIDv4.
+
+### Recommended client pattern
+
+Generate the ID once per logical operation (one user request, one
+distributed trace) and pass it through:
+
+```javascript
+const requestId = crypto.randomUUID();
+const res = await fetch(url, {
+  headers: { "Authorization": `Bearer ${token}`, "X-Request-ID": requestId },
+  ...
+});
+console.log("trace", requestId, "→", res.status);
+
+if (!res.ok) {
+  // Quote requestId in any error report or support ticket.
+  throw new Error(`Trace ${requestId} failed: ${res.status}`);
+}
+```
+
+When something goes wrong, the `X-Request-ID` you logged on the client
+side is enough for MonkAI support to pinpoint the exact server-side
+log entry — no more "what time did this happen?" ping-pong.
+
+---
+
+## Summary table
+
+| Change | Action | Required by |
+|---|---|---|
+| URL → `/v1/` | Search-replace base URL | Optional, recommended |
+| Auth → `Bearer` | Replace one header | Optional, recommended |
+| `X-Request-ID` | Generate per call, log on errors | Optional, recommended for prod |
+
+---
+
+## Compatibility window
+
+| Item | Status | Earliest removal |
+|---|---|---|
+| Unversioned `/<path>` URLs | Aliased to `/v1/` | Not announced |
+| `tracer_token` request header | Fully supported | Not announced |
+| Bulk endpoints `/records/upload` and `/logs/upload` | First-class (Python SDK uses them) | No plan to remove |
+
+Removals will be announced with at least one minor version of advance
+notice in [`API_CHANGELOG.md`](./API_CHANGELOG.md). When a removal date
+is set, this guide will get a banner at the top.

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,29 +6,45 @@
     <title>MonkAI Trace API — Reference</title>
     <link rel="icon" href="data:," />
     <link
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
       rel="stylesheet"
-      href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css"
     />
     <style>
       html, body { margin: 0; padding: 0; }
-      .topbar { display: none; }
+      .topbar {
+        display: flex;
+        gap: 16px;
+        padding: 12px 24px;
+        background: #1a1a1a;
+        color: #fafafa;
+        font-family: Montserrat, system-ui, sans-serif;
+        font-size: 14px;
+        align-items: center;
+        border-bottom: 1px solid #333;
+      }
+      .topbar a {
+        color: #fafafa;
+        text-decoration: none;
+        opacity: 0.8;
+        transition: opacity 120ms ease;
+      }
+      .topbar a:hover { opacity: 1; }
+      .topbar .brand { font-weight: 700; margin-right: 8px; }
+      .topbar .spacer { flex: 1; }
     </style>
   </head>
   <body>
-    <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-    <script>
-      window.addEventListener("load", () => {
-        window.ui = SwaggerUIBundle({
-          url: "./openapi.yaml",
-          dom_id: "#swagger-ui",
-          deepLinking: true,
-          docExpansion: "list",
-          filter: true,
-          tryItOutEnabled: false,
-          syntaxHighlight: { theme: "monokai" }
-        });
-      });
-    </script>
+    <nav class="topbar">
+      <span class="brand">MonkAI Trace API</span>
+      <a href="./MIGRATION.md">Migration guide</a>
+      <a href="./API_CHANGELOG.md">Changelog</a>
+      <a href="./http_rest_api.md">Narrative docs</a>
+      <a href="https://github.com/BeMonkAI/monkai-trace/blob/main/examples/monkai_trace.http">.http collection</a>
+      <span class="spacer"></span>
+      <a href="./openapi.yaml" download>Download spec</a>
+      <a href="https://github.com/BeMonkAI/monkai-trace">GitHub</a>
+    </nav>
+    <redoc spec-url="./openapi.yaml"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
   </body>
 </html>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -100,6 +100,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/sessions/create" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"namespace":"my-agent","user_id":"5521999998888","inactivity_timeout":300}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/sessions/create", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"namespace":"my-agent","user_id":"5521999998888","inactivity_timeout":300})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/sessions/create",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"namespace":"my-agent","user_id":"5521999998888","inactivity_timeout":300},
+            )
+            print(r.headers["x-request-id"], r.json())
   /sessions/get-or-create:
     post:
       tags: [Sessions]
@@ -140,6 +172,38 @@ paths:
   # ============================================================
   # TRACES (language-agnostic surface)
   # ============================================================
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/sessions/get-or-create" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"namespace":"my-agent","user_id":"5521999998888"}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/sessions/get-or-create", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"namespace":"my-agent","user_id":"5521999998888"})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/sessions/get-or-create",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"namespace":"my-agent","user_id":"5521999998888"},
+            )
+            print(r.headers["x-request-id"], r.json())
   /traces/llm:
     post:
       tags: [Traces]
@@ -172,6 +236,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/traces/llm" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"Hi"}]},"output":{"content":"Hello"}}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/traces/llm", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"Hi"}]},"output":{"content":"Hello"}})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/traces/llm",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"Hi"}]},"output":{"content":"Hello"}},
+            )
+            print(r.headers["x-request-id"], r.json())
   /traces/tool:
     post:
       tags: [Traces]
@@ -204,6 +300,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/traces/tool" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/traces/tool", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/traces/tool",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},
+            )
+            print(r.headers["x-request-id"], r.json())
   /traces/handoff:
     post:
       tags: [Traces]
@@ -236,6 +364,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/traces/handoff" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"session_id":"sess_abc","from_agent":"triage","to_agent":"sales","reason":"intent matched"}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/traces/handoff", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"session_id":"sess_abc","from_agent":"triage","to_agent":"sales","reason":"intent matched"})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/traces/handoff",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"session_id":"sess_abc","from_agent":"triage","to_agent":"sales","reason":"intent matched"},
+            )
+            print(r.headers["x-request-id"], r.json())
   /traces/log:
     post:
       tags: [Traces]
@@ -273,6 +433,38 @@ paths:
   # ============================================================
   # RECORDS (bulk — used by Python SDK)
   # ============================================================
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/traces/log" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"session_id":"sess_abc","level":"info","message":"step 5 done"}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/traces/log", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"session_id":"sess_abc","level":"info","message":"step 5 done"})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/traces/log",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"session_id":"sess_abc","level":"info","message":"step 5 done"},
+            )
+            print(r.headers["x-request-id"], r.json())
   /records/upload:
     post:
       tags: [Records]
@@ -310,6 +502,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/records/upload" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"records":[{"namespace":"my-agent","agent":"bot","msg":[{"role":"user","content":"hi"}]}]}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/records/upload", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"records":[{"namespace":"my-agent","agent":"bot","msg":[{"role":"user","content":"hi"}]}]})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/records/upload",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"records":[{"namespace":"my-agent","agent":"bot","msg":[{"role":"user","content":"hi"}]}]},
+            )
+            print(r.headers["x-request-id"], r.json())
   /logs/upload:
     post:
       tags: [Logs]
@@ -346,6 +570,38 @@ paths:
   # ============================================================
   # QUERY
   # ============================================================
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/logs/upload" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"logs":[{"namespace":"my-agent","level":"info","message":"hi"}]}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/logs/upload", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"logs":[{"namespace":"my-agent","level":"info","message":"hi"}]})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/logs/upload",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"logs":[{"namespace":"my-agent","level":"info","message":"hi"}]},
+            )
+            print(r.headers["x-request-id"], r.json())
   /record_query:
     post:
       tags: [Query]
@@ -378,6 +634,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/record_query" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"namespace":"my-agent","query":{"limit":50}}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/record_query", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"namespace":"my-agent","query":{"limit":50}})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/record_query",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"namespace":"my-agent","query":{"limit":50}},
+            )
+            print(r.headers["x-request-id"], r.json())
   /logs/query:
     post:
       tags: [Query]
@@ -413,6 +701,38 @@ paths:
   # ============================================================
   # EXPORT
   # ============================================================
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/logs/query" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"namespace":"my-agent","level":"error","limit":100}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/logs/query", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"namespace":"my-agent","level":"error","limit":100})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/logs/query",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"namespace":"my-agent","level":"error","limit":100},
+            )
+            print(r.headers["x-request-id"], r.json())
   /records/export:
     post:
       tags: [Export]
@@ -449,6 +769,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/records/export" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"namespace":"my-agent","format":"json"}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/records/export", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"namespace":"my-agent","format":"json"})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/records/export",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"namespace":"my-agent","format":"json"},
+            )
+            print(r.headers["x-request-id"], r.json())
   /logs/export:
     post:
       tags: [Export]
@@ -485,6 +837,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/logs/export" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"namespace":"my-agent","format":"csv"}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/logs/export", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"namespace":"my-agent","format":"csv"})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/logs/export",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"namespace":"my-agent","format":"csv"},
+            )
+            print(r.headers["x-request-id"], r.json())
 components:
   securitySchemes:
     bearerAuth:

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,0 +1,5247 @@
+{
+    "item": [
+        {
+            "name": "Sessions",
+            "description": "Manage conversation sessions.",
+            "item": [
+                {
+                    "id": "122d7420-bfbb-4b20-a079-affcaab8e144",
+                    "name": "Create a new session",
+                    "request": {
+                        "name": "Create a new session",
+                        "description": {
+                            "content": "Creates a new session for tracking a conversation flow. Use this when\nyou want to force a fresh session, regardless of recent activity.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "sessions",
+                                "create"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 7787.960214214097,\n    \"key_1\": 3078,\n    \"key_2\": 6362.038926064231,\n    \"key_3\": 3429\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "209f6056-f456-48c2-bace-22f245a88e48",
+                            "name": "Session created",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 7787.960214214097,\n    \"key_1\": 3078,\n    \"key_2\": 6362.038926064231,\n    \"key_3\": 3429\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9c5fc2d4-e951-4127-b0a1-12fc6f1f76b7",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 7787.960214214097,\n    \"key_1\": 3078,\n    \"key_2\": 6362.038926064231,\n    \"key_3\": 3429\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "011d9784-a0f7-4a42-ac41-bd5b59873a6a",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 7787.960214214097,\n    \"key_1\": 3078,\n    \"key_2\": 6362.038926064231,\n    \"key_3\": 3429\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7d2ade78-068d-46c3-a744-9d7671eb8cac",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 7787.960214214097,\n    \"key_1\": 3078,\n    \"key_2\": 6362.038926064231,\n    \"key_3\": 3429\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6a5a90c5-04e7-4c0e-adfb-9beb06066ff7",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 7787.960214214097,\n    \"key_1\": 3078,\n    \"key_2\": 6362.038926064231,\n    \"key_3\": 3429\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "227c86a7-0517-41d0-b056-3709dabd398e",
+                    "name": "Get an active session or create a new one",
+                    "request": {
+                        "name": "Get an active session or create a new one",
+                        "description": {
+                            "content": "Returns an existing active session for `(namespace, user_id)` if there\nwas activity within `inactivity_timeout` seconds; otherwise creates a\nnew one. This is the endpoint used by the Python SDK to keep session\ncontinuity across stateless environments (REST APIs, serverless).\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "sessions",
+                                "get-or-create"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "265721e1-d959-4fc2-bf10-9c016c65cb48",
+                            "name": "Session returned (existing or new)",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "get-or-create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 3679.377344026027,\n    \"key_1\": false\n  },\n  \"reused\": \"<boolean>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "1c1f20e2-c4b1-47d0-a557-029748217083",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "get-or-create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "71fae891-f381-40d4-8784-e0ab851a05c8",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "get-or-create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "615cb2bd-273b-4f8e-9941-18da4123b036",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "get-or-create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "75cf64ac-846c-41fb-902c-c2d687924bc4",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "get-or-create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Traces",
+            "description": "Record fine-grained events. Preferred for HTTP clients in any language.",
+            "item": [
+                {
+                    "id": "37f4d039-d0a7-4dfa-aae6-69fb0e0facba",
+                    "name": "Trace an LLM call",
+                    "request": {
+                        "name": "Trace an LLM call",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "traces",
+                                "llm"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 1465.6751039162364,\n    \"key_1\": 6364,\n    \"key_2\": false\n  },\n  \"output\": {\n    \"key_0\": 3801.1586815593246\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 396.1880171004595,\n    \"key_1\": \"string\",\n    \"key_2\": 6657\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "bff39bf9-cd36-42b6-8f99-62df4a50dd90",
+                            "name": "Trace recorded",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 1465.6751039162364,\n    \"key_1\": 6364,\n    \"key_2\": false\n  },\n  \"output\": {\n    \"key_0\": 3801.1586815593246\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 396.1880171004595,\n    \"key_1\": \"string\",\n    \"key_2\": 6657\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"tokens\": {\n    \"input\": \"<integer>\",\n    \"output\": \"<integer>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "b3428e03-22b9-4785-8ef2-3b09ef95c242",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 1465.6751039162364,\n    \"key_1\": 6364,\n    \"key_2\": false\n  },\n  \"output\": {\n    \"key_0\": 3801.1586815593246\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 396.1880171004595,\n    \"key_1\": \"string\",\n    \"key_2\": 6657\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "35250524-6bca-4e44-be32-392efdb63a76",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 1465.6751039162364,\n    \"key_1\": 6364,\n    \"key_2\": false\n  },\n  \"output\": {\n    \"key_0\": 3801.1586815593246\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 396.1880171004595,\n    \"key_1\": \"string\",\n    \"key_2\": 6657\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "86455d7d-ec14-4f0c-8d23-81f99096d360",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 1465.6751039162364,\n    \"key_1\": 6364,\n    \"key_2\": false\n  },\n  \"output\": {\n    \"key_0\": 3801.1586815593246\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 396.1880171004595,\n    \"key_1\": \"string\",\n    \"key_2\": 6657\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2809dcfd-4ba9-45e6-b3d7-3880e86b6716",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 1465.6751039162364,\n    \"key_1\": 6364,\n    \"key_2\": false\n  },\n  \"output\": {\n    \"key_0\": 3801.1586815593246\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 396.1880171004595,\n    \"key_1\": \"string\",\n    \"key_2\": 6657\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "086aa988-3363-41ca-9cd7-0b44dea21e4f",
+                    "name": "Trace a tool/function call",
+                    "request": {
+                        "name": "Trace a tool/function call",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "traces",
+                                "tool"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4944\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"email\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "84248e6c-bac4-4922-9ed5-cc401bcffb6f",
+                            "name": "Trace recorded",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4944\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"email\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"tool_name\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5eb8f032-3ae1-45bc-a917-e46ad89d64be",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4944\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"email\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e2a2cf07-97be-44e3-afaf-0c1b36fb9925",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4944\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"email\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "539a9908-62be-404e-b17e-d0d7d2c8cef7",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4944\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"email\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f4d1201f-2136-47e3-8b8e-7000b0c5687f",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4944\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"email\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "217dccbe-816e-4392-874e-c8b050dad887",
+                    "name": "Trace an agent-to-agent handoff",
+                    "request": {
+                        "name": "Trace an agent-to-agent handoff",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "traces",
+                                "handoff"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 1030.3919988226785,\n    \"key_2\": \"string\",\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"other\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "96dc2d23-b157-423d-b11b-6d13804b8243",
+                            "name": "Trace recorded",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 1030.3919988226785,\n    \"key_2\": \"string\",\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"other\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"from\": \"<string>\",\n  \"to\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "119b431d-b8a3-4831-b3ea-87538dcb447f",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 1030.3919988226785,\n    \"key_2\": \"string\",\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"other\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "761f6a96-0750-4422-936d-a276cc8a3d6e",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 1030.3919988226785,\n    \"key_2\": \"string\",\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"other\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e2bfd8a5-e10f-4f10-acca-68f8885a2882",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 1030.3919988226785,\n    \"key_2\": \"string\",\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"other\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "07c0de0b-7336-4e42-9906-f6d7b525f7ef",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 1030.3919988226785,\n    \"key_2\": \"string\",\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"other\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "992e5180-7718-4a8d-9a69-e8e66d7802d8",
+                    "name": "Trace a log entry",
+                    "request": {
+                        "name": "Trace a log entry",
+                        "description": {
+                            "content": "Records a log entry. Either `session_id` or `namespace` must be provided.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "traces",
+                                "log"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4829\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "2b28e56a-9d82-49e7-a4ab-93ae66bf6ba8",
+                            "name": "Log recorded",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4829\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2b072c3d-cb19-4808-8362-edc52d1b5087",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4829\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5de5f754-8309-4f7d-a86c-832fa649fb91",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4829\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d3cc364e-4dde-4598-9f36-0daf2c20e88a",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4829\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "dce83965-b151-402f-bb59-0186da9d40af",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4829\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Records",
+            "description": "Conversation records (used by the Python SDK and for batch imports).",
+            "item": [
+                {
+                    "id": "75be4595-f85b-4b52-a259-392d797453be",
+                    "name": "Upload conversation records (batch)",
+                    "request": {
+                        "name": "Upload conversation records (batch)",
+                        "description": {
+                            "content": "Batch upload of conversation records. Used by the Python SDK\n(`MonkAIClient.upload_record` / `upload_records_batch`). Server-side\ndeduplication is applied; the response indicates how many were inserted\nvs. dropped as duplicates.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "records",
+                                "upload"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": 6621.615967166946,\n            \"key_2\": 7992.124882857625\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    }\n  ]\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "ca6d1e40-4448-4c55-bc70-b723c5e931d6",
+                            "name": "Records processed",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": 6621.615967166946,\n            \"key_2\": 7992.124882857625\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": 4836\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "79995a37-2b9e-4888-b34d-56763c4fe137",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": 6621.615967166946,\n            \"key_2\": 7992.124882857625\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "c530422e-f81e-484a-a1a1-4cddf3a710d0",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": 6621.615967166946,\n            \"key_2\": 7992.124882857625\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6baee072-ac18-46d5-a19a-3cc5c3dd3dee",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": 6621.615967166946,\n            \"key_2\": 7992.124882857625\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f510c393-e608-4e00-b775-a34e4bb64ebc",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": 6621.615967166946,\n            \"key_2\": 7992.124882857625\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Logs",
+            "description": "Operational log entries.",
+            "item": [
+                {
+                    "id": "c637b1e1-a587-445e-896b-6537e7a416b9",
+                    "name": "Upload operational logs (batch)",
+                    "request": {
+                        "name": "Upload operational logs (batch)",
+                        "description": {
+                            "content": "Batch upload of structured log entries.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "logs",
+                                "upload"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "dbdb1022-dafa-42c4-89c0-e336f784684c",
+                            "name": "Logs processed",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": \"string\",\n  \"key_1\": 7699\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3bf982ce-ce74-48db-b62e-3e05dea55558",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9f087703-1d96-4ec5-96ba-dcc0899b36ae",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "8d7f89e1-4c8d-4d98-a518-870ebb58644d",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "c16bf31c-e47f-4004-a3c3-4a0b65a28f46",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Query",
+            "description": "Read records and logs.",
+            "item": [
+                {
+                    "id": "f13b1969-a973-44d4-9853-5ec4d29c90c8",
+                    "name": "Query conversation records",
+                    "request": {
+                        "name": "Query conversation records",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "record_query"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "06b21990-b229-48f2-a8e8-74f83b646a24",
+                            "name": "Records matching the query",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "record_query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 9030,\n            \"key_1\": false\n          },\n          {\n            \"key_0\": 9904.558226434101\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"email\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 4684\n          },\n          {\n            \"key_0\": 111\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "0d1a42a1-24d1-4ff1-936b-1b6527d8830f",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "record_query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "385e0f07-34a4-49fe-88bc-8b167055d23b",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "record_query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "b83d3fe0-e6ad-49f3-8985-fc9510392b7d",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "record_query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5d3e5616-b762-415b-9d78-b4f2f0106af7",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "record_query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "10ca4467-7196-411c-9352-fa99e5600fb7",
+                    "name": "Query log entries",
+                    "request": {
+                        "name": "Query log entries",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "logs",
+                                "query"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "d4c4f709-0c4e-400f-86e5-463b6a3bcae0",
+                            "name": "Logs matching the query",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 9687.637208938973,\n        \"key_1\": 7680.524015896116,\n        \"key_2\": 9876\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fbe59157-a45e-41d0-9eeb-7bcf7152b930",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a147deb4-e14f-42de-acd5-571262219f51",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e2b67806-6927-4a6e-8ee8-ff02e1dc0045",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "754b7a78-daf7-444b-8f3f-86c27dc3ace1",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Export",
+            "description": "Bulk export with server-side pagination.",
+            "item": [
+                {
+                    "id": "90cf94d9-733b-4f7c-bb1f-20ba2f39f6c0",
+                    "name": "Export conversation records (JSON or CSV)",
+                    "request": {
+                        "name": "Export conversation records (JSON or CSV)",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "records",
+                                "export"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "0e0be57e-b75d-4ea0-8a01-2cf0ba3e9fac",
+                            "name": "Records exported",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 3486\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"voice\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": false\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 9313\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "c9540e23-444d-4628-af72-dc18127abdf2",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "393cdac4-e029-406f-84ed-eafa0869977d",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "58ec5ffc-2a50-412f-a2fa-6636953cc685",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fcf7f2ac-018d-48e3-b368-15bf12e284da",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "28818026-0a62-40bc-9d69-1a6d481eb826",
+                    "name": "Export logs (JSON or CSV)",
+                    "request": {
+                        "name": "Export logs (JSON or CSV)",
+                        "description": {},
+                        "url": {
+                            "path": [
+                                "logs",
+                                "export"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "7498f3c2-40c8-4787-949e-bd9d71105295",
+                            "name": "Logs exported",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 4206.44472920176,\n        \"key_1\": false,\n        \"key_2\": 5467\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2b95c930-ac4f-48d4-9bae-303fc98eec3b",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "17d7f039-30e6-438d-a1c4-65d37bd877e2",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "655af38b-6315-4982-a3b0-f887a5523bcf",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "50d851cf-cc07-4b6b-9082-c7616218fd5a",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "(3LfRv[~E^C1[$4fOW\\3Ge}W:D 2QtSF|=||L?vns;YCT}%ZvqX_OoXEaJ&i4bA[_@JP+OAQRDTM]e'tlNGR2zsHLwAD[>x{J6(9y[:P~/h'yd/(QuI7T"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": \"<string>\",\n  \"key_0\": \"string\",\n  \"key_1\": 3489,\n  \"key_2\": true\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        }
+    ],
+    "auth": {
+        "type": "bearer",
+        "bearer": [
+            {
+                "type": "any",
+                "value": "{{bearerToken}}",
+                "key": "token"
+            }
+        ]
+    },
+    "event": [],
+    "variable": [
+        {
+            "key": "baseUrl",
+            "value": "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1"
+        }
+    ],
+    "info": {
+        "_postman_id": "49288ac7-4d5c-4cf0-a3a3-e4c42a8e3a31",
+        "name": "MonkAI Trace API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "description": {
+            "content": "The MonkAI Trace REST API exposes the same backend used by the official\nPython SDK (`monkai-trace`) so that any runtime (Node.js, Go, Java, .NET,\nRust, etc.) can send traces without depending on the SDK.\n\nThe API has three logical surfaces:\n\n1. **Sessions** — track a logical conversation across multiple traces.\n2. **Traces** — fine-grained events (LLM call, tool call, agent handoff, log).\n   Recommended for non-Python integrations.\n3. **Records / Logs** — bulk endpoints used by the Python SDK and for batch\n   imports of historical data. Useful when an integration already produces\n   full conversation records.\n\nAll endpoints accept JSON, return JSON, and require a tracer token. See\n[`docs/http_rest_api.md`](./http_rest_api.md) for narrative documentation.\n\n\nContact Support:\n Name: MonkAI",
+            "type": "text/plain"
+        }
+    }
+}

--- a/scripts/add_code_samples.py
+++ b/scripts/add_code_samples.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Inject `x-codeSamples` into every operation in `docs/openapi.yaml`.
+
+Renders three samples per operation:
+
+  - cURL with `Authorization: Bearer` and the `/v1/` base URL
+  - Node.js using the native `fetch` API (Node 18+)
+  - Python using the `requests` library
+
+Run from the repo root:
+
+    .venv/bin/python scripts/add_code_samples.py
+
+Idempotent — overwrites any existing `x-codeSamples` block.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString
+
+API_BASE = "https://api.monkai.ai/trace/v1"
+LEGACY_BASE = (
+    "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1"
+)
+TOKEN_ENV = "MONKAI_TRACER_TOKEN"
+
+
+def example_payload(operation_id: str) -> str:
+    """Concrete example bodies, kept short for readability."""
+    if operation_id == "createSession":
+        return '{"namespace":"my-agent","user_id":"5521999998888","inactivity_timeout":300}'
+    if operation_id == "getOrCreateSession":
+        return '{"namespace":"my-agent","user_id":"5521999998888"}'
+    if operation_id == "traceLlmCall":
+        return (
+            '{"session_id":"sess_abc","model":"gpt-4","input":{"messages":'
+            '[{"role":"user","content":"Hi"}]},"output":{"content":"Hello"}}'
+        )
+    if operation_id == "traceToolCall":
+        return (
+            '{"session_id":"sess_abc","tool_name":"get_weather",'
+            '"arguments":{"city":"SP"},"result":{"temp":24}}'
+        )
+    if operation_id == "traceHandoff":
+        return (
+            '{"session_id":"sess_abc","from_agent":"triage",'
+            '"to_agent":"sales","reason":"intent matched"}'
+        )
+    if operation_id == "traceLog":
+        return '{"session_id":"sess_abc","level":"info","message":"step 5 done"}'
+    if operation_id == "uploadRecords":
+        return (
+            '{"records":[{"namespace":"my-agent","agent":"bot",'
+            '"msg":[{"role":"user","content":"hi"}]}]}'
+        )
+    if operation_id == "uploadLogs":
+        return '{"logs":[{"namespace":"my-agent","level":"info","message":"hi"}]}'
+    if operation_id == "queryRecords":
+        return '{"namespace":"my-agent","query":{"limit":50}}'
+    if operation_id == "queryLogs":
+        return '{"namespace":"my-agent","level":"error","limit":100}'
+    if operation_id == "exportRecords":
+        return '{"namespace":"my-agent","format":"json"}'
+    if operation_id == "exportLogs":
+        return '{"namespace":"my-agent","format":"csv"}'
+    return "{}"
+
+
+def curl_sample(path: str, body: str) -> str:
+    return (
+        f"curl -X POST \"{API_BASE}{path}\" \\\n"
+        f"  -H \"Authorization: Bearer ${TOKEN_ENV}\" \\\n"
+        f"  -H \"Content-Type: application/json\" \\\n"
+        f"  -H \"X-Request-ID: $(uuidgen)\" \\\n"
+        f"  -d '{body}'\n"
+    )
+
+
+def node_sample(path: str, body: str) -> str:
+    return (
+        "// Node.js 18+ — no dependencies\n"
+        f"const res = await fetch(\"{API_BASE}{path}\", {{\n"
+        "  method: \"POST\",\n"
+        "  headers: {\n"
+        f"    \"Authorization\": `Bearer ${{process.env.{TOKEN_ENV}}}`,\n"
+        "    \"Content-Type\": \"application/json\"\n"
+        "  },\n"
+        f"  body: JSON.stringify({body})\n"
+        "});\n"
+        "console.log(res.headers.get(\"x-request-id\"), await res.json());\n"
+    )
+
+
+def python_sample(path: str, body: str) -> str:
+    return (
+        "import os, requests\n"
+        f"r = requests.post(\n"
+        f"    \"{API_BASE}{path}\",\n"
+        f"    headers={{\"Authorization\": f\"Bearer {{os.environ['{TOKEN_ENV}']}}\"}},\n"
+        f"    json={body},\n"
+        f")\n"
+        f"print(r.headers[\"x-request-id\"], r.json())\n"
+    )
+
+
+def build_code_samples(path: str, operation_id: str) -> list[dict]:
+    body = example_payload(operation_id)
+    return [
+        {"lang": "Shell", "label": "curl", "source": LiteralScalarString(curl_sample(path, body))},
+        {"lang": "JavaScript", "label": "Node.js", "source": LiteralScalarString(node_sample(path, body))},
+        {"lang": "Python", "label": "Python", "source": LiteralScalarString(python_sample(path, body))},
+    ]
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    spec_path = repo_root / "docs" / "openapi.yaml"
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    with spec_path.open() as f:
+        spec = yaml.load(f)
+
+    paths = spec.get("paths", {})
+    touched = 0
+    for path, item in paths.items():
+        for method, op in item.items():
+            if not isinstance(op, dict) or "operationId" not in op:
+                continue
+            op["x-codeSamples"] = build_code_samples(path, op["operationId"])
+            touched += 1
+
+    with spec_path.open("w") as f:
+        yaml.dump(spec, f)
+
+    print(f"Injected x-codeSamples into {touched} operations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## O que foi feito

Fase 4 do API Roadmap ([#13](https://github.com/BeMonkAI/monkai-trace/issues/13)). Site de docs dedicado pra REST API com tudo que dev externo precisa pra integrar em < 5 min.

### Entregáveis

- **\`docs/index.html\`** — ReDoc no lugar do Swagger UI. Topbar com links pra Migration, Changelog, narrative docs, .http collection, download do spec, GitHub. ReDoc renderiza \`x-codeSamples\` nativo (Swagger UI não fazia tão bem) e tem navegação melhor.
- **\`docs/openapi.yaml\`** — \`x-codeSamples\` adicionado em cada uma das 12 operações: curl, Node.js (fetch), Python (requests). Todos usando \`Authorization: Bearer\`, \`/v1/\` e demonstrando \`X-Request-ID\`.
- **\`scripts/add_code_samples.py\`** — gerador idempotente em ruamel.yaml. Rodar de novo quando lista de operações mudar.
- **\`docs/API_CHANGELOG.md\`** — changelog dedicado da REST API, separado do CHANGELOG do SDK Python. Baseline v1 + roadmap das Fases 2/3.
- **\`docs/MIGRATION.md\`** — guia opt-in com diffs lado a lado pras 3 mudanças de Fase 2 (URL→/v1/, header→Bearer, X-Request-ID), tabela de compatibilidade no final.
- **\`docs/postman_collection.json\`** — Postman v2.1.0, 12 requests, 6 folders por tag. Gerado via \`openapi-to-postmanv2\`.
- **CI \`postman-collection\`** — sanity check do arquivo (schema v2.1.0, >=6 folders, >=6 requests). Não faz diff estrito porque o gerador usa valores fake aleatórios pra free-form objects, mas pega regressões reais (truncamento, schema drift).
- **\`README.md\`** — callout no topo apontando pra GitHub Pages + arquivos de doc.

## Por que

Critério de aceite da issue [#13](https://github.com/BeMonkAI/monkai-trace/issues/13): \"dev novo (sem contexto MonkAI) manda primeiro trace em < 5 min lendo só os docs\". ReDoc + code samples em 3 linguagens + Postman pronto pra importar fecham esse loop sem forçar o dev a escrever HTTP boilerplate.

## O que NÃO está nesse PR

- **Custom domain \`docs.monkai.ai/trace/api\`** — depende de DNS access e decisão separada. Vou abrir issue tracking pra fazer depois.
- **Go/Java code samples** — issue #13 listava 5 linguagens; entreguei 3 (curl/Node/Python) que cobrem >90% dos casos imediatos. Adicionar mais é trivial via \`scripts/add_code_samples.py\` quando houver demanda.

## Como testar

\`\`\`bash
# Validacao OpenAPI + Redocly lint
.venv/bin/python -c \"from openapi_spec_validator import validate; import yaml; validate(yaml.safe_load(open('docs/openapi.yaml')))\"
npx --yes @redocly/cli@latest lint docs/openapi.yaml

# Postman sanity (replica do CI step)
node -e \"
const c = JSON.parse(require('fs').readFileSync('docs/postman_collection.json'));
console.log('schema:', c.info.schema);
console.log('folders:', c.item.length, '/ requests:', c.item.flatMap(f => f.item).length);
\"

# ReDoc local
open docs/index.html
\`\`\`

## Checklist

- [x] OpenAPI 3.1 valido + Redocly zero warnings
- [x] 12 operações com x-codeSamples (3 linguagens cada)
- [x] Postman collection valida (v2.1.0, 12 requests, 6 folders)
- [x] ReDoc renderiza local (testado abrindo docs/index.html)
- [x] CI \`postman-collection\` job adicionado
- [x] README com callout pro site
- [x] Mudança 100% docs/CI — zero impacto runtime

## Após merge

1. Pages auto-rebuilda em ~1 min — testar \`https://bemonkai.github.io/monkai-trace/\` e ver ReDoc novo
2. Issue #13 fecha automaticamente
3. Abrir issue \"Custom domain docs.monkai.ai/trace/api\" como follow-up

Closes #13

Refs #11 (Phase 2), #12 (Phase 3 — listed in API_CHANGELOG)