### PR TITLE
docs(api): /v1/health + /v1/traces/batch (companion to monkai-hub#22/#23)

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: "20"
 
       - name: Redocly lint
-        run: npx --yes @redocly/cli@latest lint docs/openapi.yaml
+        run: npx --yes @redocly/cli@latest lint docs/openapi.yaml --config docs/redocly.yaml
 
   generate-typescript-client:
     name: Smoke-test TS client generation

--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -12,14 +12,26 @@ keep working during a deprecation window.
 
 ## [Unreleased]
 
-### Planned (Phase 3)
+### Planned (Phase 3 — remaining)
 - `Idempotency-Key` header for `POST /traces/*` and `POST /v1/traces/batch`.
-- Batch endpoint `POST /v1/traces/batch` for mixed `llm`/`tool`/`handoff`/`log` payloads.
 - Rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
-- `GET /v1/health` health-check endpoint.
 
 ### Planned (Phase 2 — remaining)
 - Custom domain `https://api.monkai.ai/trace/v1`.
+
+## [v1.2] — 2026-05-02
+
+### Added
+- **`GET /v1/health`** (and `HEAD /v1/health`) — unauthenticated
+  liveness probe returning `{status, service, api_version, timestamp}`.
+  No auth required; suitable for monitors, uptime checks, and
+  post-deploy smoke tests. Reference: [BeMonkAI/monkai-agent-hub#22](https://github.com/BeMonkAI/monkai-agent-hub/pull/22).
+- **`POST /v1/traces/batch`** — submit up to 100 mixed traces
+  (`llm` | `tool` | `handoff` | `log`) in a single request. Partial
+  success is allowed: response is always 200 when the outer envelope
+  is well-formed, with per-item `status: "ok" | "error"`. Cuts N
+  round-trips down to 1 for clients that produce multiple traces per
+  user interaction. Reference: [BeMonkAI/monkai-agent-hub#23](https://github.com/BeMonkAI/monkai-agent-hub/pull/23).
 
 ## [v1.1] — 2026-05-02
 

--- a/docs/http_rest_api.md
+++ b/docs/http_rest_api.md
@@ -76,6 +76,38 @@ These fields enable:
 
 ## Endpoints
 
+### Health Check — `GET /v1/health`
+
+Cheap, unauthenticated liveness probe. Use it for monitors, uptime
+checks, and post-deploy smoke tests.
+
+**Headers:**
+- *(none required)*
+- `X-Request-ID` *(optional)*: client-supplied trace ID, returned round-trip
+
+**Response (200):**
+```json
+{
+  "status": "ok",
+  "service": "monkai-trace",
+  "api_version": "v1",
+  "timestamp": "2026-05-02T11:52:02.199Z"
+}
+```
+
+`HEAD /v1/health` is also accepted (RFC 7231) and returns the same
+headers without a body.
+
+**Example:**
+```bash
+curl https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/health
+
+# HEAD-only (for bandwidth-sensitive monitors)
+curl -I https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/health
+```
+
+---
+
 ### Create Session — `POST /sessions/create`
 
 Creates a new session for tracking a conversation flow.
@@ -321,6 +353,72 @@ curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1
     "level": "info",
     "message": "User completed onboarding flow",
     "metadata": { "step": 5, "duration_ms": 3200 }
+  }'
+```
+
+---
+
+### Batch Traces — `POST /v1/traces/batch`
+
+Submit up to **100 mixed traces** in a single request. Each item
+carries a `type` field (`llm`, `tool`, `handoff`, `log`) plus the same
+body shape as the per-type endpoint, minus `type`.
+
+**When to use it.** Whenever a single client interaction produces
+multiple traces (e.g., an LLM call → tool call → log) — cuts N
+round-trips down to 1.
+
+**Headers:**
+- `Authorization: Bearer tk_<token>` *or* `tracer_token: tk_<token>` — required
+- `Content-Type`: `application/json`
+- `X-Request-ID` *(optional)*: returned round-trip
+
+**Body:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `traces` | array | Yes | 1–100 items. Each item `{type, ...payload}`. |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "total": 3,
+  "succeeded": 3,
+  "failed": 0,
+  "results": [
+    { "index": 0, "type": "llm",  "status": "ok", "result": {"trace_type": "llm_call", "tokens": {"input": 12, "output": 15}, "credits_charged": 0.001} },
+    { "index": 1, "type": "tool", "status": "ok", "result": {"trace_type": "tool_call", "tool_name": "get_weather"} },
+    { "index": 2, "type": "log",  "status": "ok", "result": {"trace_type": "log"} }
+  ]
+}
+```
+
+**Partial success.** When the outer envelope is well-formed, the
+response is **always 200**, even if some items errored. Inspect
+`results[i].status`. The outer `success` is `true` only when every
+item succeeded.
+
+**Per-item errors** carry the standard `{code, message}` shape:
+
+```json
+{ "index": 1, "type": "handoff", "status": "error", "error": { "code": "missing_field", "message": "from_agent is required" } }
+```
+
+**Limits.** Max 100 items per call. Empty arrays return 400. Invalid
+JSON returns 400.
+
+**Example:**
+```bash
+curl -X POST https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/batch \
+  -H "Authorization: Bearer tk_YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "traces": [
+      { "type": "llm",  "session_id": "sess_abc", "model": "gpt-4", "input": {"messages":[{"role":"user","content":"hi"}]}, "output": {"content":"hello"} },
+      { "type": "tool", "session_id": "sess_abc", "tool_name": "get_weather", "arguments": {"city":"SP"}, "result": {"temp": 24} },
+      { "type": "log",  "session_id": "sess_abc", "level": "info", "message": "done" }
+    ]
   }'
 ```
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -35,6 +35,8 @@ servers:
     description: Production (planned custom domain — Phase 2)
 
 tags:
+  - name: Health
+    description: Liveness check (no auth required).
   - name: Sessions
     description: Manage conversation sessions.
   - name: Traces
@@ -53,6 +55,67 @@ security:
   - tracerTokenHeader: []
 
 paths:
+  # ============================================================
+  # HEALTH (no auth)
+  # ============================================================
+  /health:
+    get:
+      tags: [Health]
+      summary: Liveness check
+      description: |
+        Cheap, unauthenticated liveness probe. Returns `200` with a small
+        JSON body when the edge function is responsive. Use it for
+        monitors, uptime checks, and post-deploy smoke tests. Also
+        supports `HEAD` (RFC 7231) — returns the same headers without
+        a body so HEAD-based monitors don't waste bandwidth.
+      operationId: healthCheck
+      security: []
+      responses:
+        "200":
+          description: Service is responsive
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl "https://api.monkai.ai/trace/v1/health"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies, no auth required
+            const res = await fetch("https://api.monkai.ai/trace/v1/health", { method: "GET" });
+            console.log(res.status, res.headers.get("x-request-id"));
+        - lang: Python
+          label: Python
+          source: |
+            import requests
+            r = requests.get("https://api.monkai.ai/trace/v1/health")
+            print(r.status_code, r.headers["x-request-id"])
+    head:
+      tags: [Health]
+      summary: Liveness check (HEAD variant)
+      description: |
+        Same semantics as `GET /health` but returns no body. Useful for
+        bandwidth-sensitive monitors.
+      operationId: healthCheckHead
+      security: []
+      responses:
+        "200":
+          description: Service is responsive (no body)
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   # ============================================================
   # SESSIONS
   # ============================================================
@@ -463,6 +526,87 @@ paths:
                 "https://api.monkai.ai/trace/v1/traces/log",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"session_id":"sess_abc","level":"info","message":"step 5 done"},
+            )
+            print(r.headers["x-request-id"], r.json())
+  /traces/batch:
+    post:
+      tags: [Traces]
+      summary: Batch trace endpoint (mixed types)
+      description: |
+        Submit up to 100 traces in a single request. Each item carries a
+        `type` field (`llm` | `tool` | `handoff` | `log`) and the same
+        body shape as the per-type endpoint, minus the `type` field.
+
+        **Partial success is allowed.** When the outer envelope is
+        well-formed, the response is always `200`; per-item status is
+        reported in the `results` array (`status: "ok"` or
+        `status: "error"`). The outer `success` is `true` only when
+        every item succeeded.
+
+        Use this whenever a single client interaction produces multiple
+        traces (an LLM call followed by a tool call, plus a log entry,
+        for example) — it cuts N round-trips down to one.
+      operationId: traceBatch
+      parameters:
+        - $ref: "#/components/parameters/RequestIdHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchTraceRequest"
+      responses:
+        "200":
+          description: |
+            Batch processed. Inspect `results` for per-item status.
+            `failed > 0` means at least one item errored — the others
+            were still recorded.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchTraceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -X POST "https://api.monkai.ai/trace/v1/traces/batch" \
+              -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
+              -H "Content-Type: application/json" \
+              -H "X-Request-ID: $(uuidgen)" \
+              -d '{"traces":[{"type":"llm","session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"hi"}]},"output":{"content":"hello"}},{"type":"tool","session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},{"type":"log","session_id":"sess_abc","level":"info","message":"done"}]}'
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            // Node.js 18+ — no dependencies
+            const res = await fetch("https://api.monkai.ai/trace/v1/traces/batch", {
+              method: "POST",
+              headers: {
+                "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
+                "Content-Type": "application/json"
+              },
+              body: JSON.stringify({"traces":[{"type":"llm","session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"hi"}]},"output":{"content":"hello"}},{"type":"tool","session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},{"type":"log","session_id":"sess_abc","level":"info","message":"done"}]})
+            });
+            console.log(res.headers.get("x-request-id"), await res.json());
+        - lang: Python
+          label: Python
+          source: |
+            import os, requests
+            r = requests.post(
+                "https://api.monkai.ai/trace/v1/traces/batch",
+                headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
+                json={"traces":[{"type":"llm","session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"hi"}]},"output":{"content":"hello"}},{"type":"tool","session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},{"type":"log","session_id":"sess_abc","level":"info","message":"done"}]},
             )
             print(r.headers["x-request-id"], r.json())
   /records/upload:
@@ -955,6 +1099,160 @@ components:
 
   schemas:
     # ---------- Common ----------
+    HealthResponse:
+      type: object
+      required: [status, service, api_version, timestamp]
+      properties:
+        status:
+          type: string
+          enum: [ok]
+          description: Always `ok` when the endpoint responds.
+        service:
+          type: string
+          example: monkai-trace
+        api_version:
+          type: string
+          description: |
+            Detected URL version. `v1` for `/v1/health`; the legacy
+            unversioned `/health` also reports `v1` (it acts as a v1
+            alias).
+          example: v1
+        timestamp:
+          type: string
+          format: date-time
+          description: Server-side timestamp at the moment of the response.
+
+    BatchTraceItem:
+      type: object
+      required: [type]
+      discriminator:
+        propertyName: type
+        mapping:
+          llm: "#/components/schemas/BatchTraceItemLlm"
+          tool: "#/components/schemas/BatchTraceItemTool"
+          handoff: "#/components/schemas/BatchTraceItemHandoff"
+          log: "#/components/schemas/BatchTraceItemLog"
+      properties:
+        type:
+          type: string
+          enum: [llm, tool, handoff, log]
+          description: Selects the per-type body shape.
+      oneOf:
+        - $ref: "#/components/schemas/BatchTraceItemLlm"
+        - $ref: "#/components/schemas/BatchTraceItemTool"
+        - $ref: "#/components/schemas/BatchTraceItemHandoff"
+        - $ref: "#/components/schemas/BatchTraceItemLog"
+
+    BatchTraceItemLlm:
+      allOf:
+        - type: object
+          required: [type]
+          properties:
+            type:
+              type: string
+              const: llm
+        - $ref: "#/components/schemas/LlmTraceRequest"
+
+    BatchTraceItemTool:
+      allOf:
+        - type: object
+          required: [type]
+          properties:
+            type:
+              type: string
+              const: tool
+        - $ref: "#/components/schemas/ToolTraceRequest"
+
+    BatchTraceItemHandoff:
+      allOf:
+        - type: object
+          required: [type]
+          properties:
+            type:
+              type: string
+              const: handoff
+        - $ref: "#/components/schemas/HandoffTraceRequest"
+
+    BatchTraceItemLog:
+      allOf:
+        - type: object
+          required: [type]
+          properties:
+            type:
+              type: string
+              const: log
+        - $ref: "#/components/schemas/LogTraceRequest"
+
+    BatchTraceRequest:
+      type: object
+      required: [traces]
+      properties:
+        traces:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/BatchTraceItem"
+
+    BatchTraceResultItem:
+      type: object
+      required: [index, type, status]
+      properties:
+        index:
+          type: integer
+          minimum: 0
+          description: Position in the request `traces` array.
+        type:
+          type: string
+          enum: [llm, tool, handoff, log]
+        status:
+          type: string
+          enum: [ok, error]
+        result:
+          description: |
+            Present when `status === "ok"`. Shape mirrors the per-type
+            response (`LlmTraceResponse`, `ToolTraceResponse`, etc.)
+            minus the `success` flag.
+          oneOf:
+            - $ref: "#/components/schemas/LlmTraceResponse"
+            - $ref: "#/components/schemas/ToolTraceResponse"
+            - $ref: "#/components/schemas/HandoffTraceResponse"
+            - $ref: "#/components/schemas/LogTraceResponse"
+        error:
+          description: |
+            Present when `status === "error"`. Same shape as the
+            error envelope, minus the wrapping `error` key.
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+
+    BatchTraceResponse:
+      type: object
+      required: [success, total, succeeded, failed, results]
+      properties:
+        success:
+          type: boolean
+          description: |
+            `true` only when every item succeeded. Inspect `results`
+            for per-item status.
+        total:
+          type: integer
+          minimum: 0
+        succeeded:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchTraceResultItem"
+
     Error:
       type: object
       description: |
@@ -998,8 +1296,7 @@ components:
               example: missing_token
             message:
               type: string
-              description: Human-readable message. Subject to wording
-                changes — do not pattern-match.
+              description: Human-readable message. Subject to wording changes — do not pattern-match.
               example: "Missing tracer token (use `tracer_token` header or `Authorization: Bearer tk_...`)"
             request_id:
               type: string

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,11 +1,288 @@
 {
     "item": [
         {
+            "name": "Health",
+            "description": "Liveness check (no auth required).",
+            "item": [
+                {
+                    "id": "2ef8498d-68f4-434c-a5bd-3229f63320f7",
+                    "name": "Liveness check",
+                    "request": {
+                        "name": "Liveness check",
+                        "description": {
+                            "content": "Cheap, unauthenticated liveness probe. Returns `200` with a small\nJSON body when the edge function is responsive. Use it for\nmonitors, uptime checks, and post-deploy smoke tests. Also\nsupports `HEAD` (RFC 7231) — returns the same headers without\na body so HEAD-based monitors don't waste bandwidth.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "health"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "e5b5c077-4642-405f-902a-104766c71103",
+                            "name": "Service is responsive",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "health"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"status\": \"ok\",\n  \"service\": \"<string>\",\n  \"api_version\": \"<string>\",\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5fc57067-51de-4a0c-a284-3b9eedc7abbb",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "health"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "f04962f8-9c8b-4d76-ad19-131fc824b2d0",
+                    "name": "Liveness check (HEAD variant)",
+                    "request": {
+                        "name": "Liveness check (HEAD variant)",
+                        "description": {
+                            "content": "Same semantics as `GET /health` but returns no body. Useful for\nbandwidth-sensitive monitors.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "health"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "HEAD",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "03f18fe3-2216-4fdc-88cc-967e280dbb2f",
+                            "name": "Service is responsive (no body)",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "health"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "HEAD",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "cookie": [],
+                            "_postman_previewlanguage": "text"
+                        },
+                        {
+                            "id": "e226f1a0-8761-4649-8a37-9b10857bf5c9",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "health"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "HEAD",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                }
+            ]
+        },
+        {
             "name": "Sessions",
             "description": "Manage conversation sessions.",
             "item": [
                 {
-                    "id": "60acfb02-4ba2-47ce-a9ef-f905fb71180a",
+                    "id": "3ebb1a79-20ba-4fac-9ef3-20e791a2ee6f",
                     "name": "Create a new session",
                     "request": {
                         "name": "Create a new session",
@@ -32,7 +309,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -46,7 +323,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 99,\n    \"key_1\": \"string\",\n    \"key_2\": 135\n  }\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -58,7 +335,7 @@
                     },
                     "response": [
                         {
-                            "id": "9ea3d132-8e26-4964-ad74-d521e24c678d",
+                            "id": "c0b81a27-b26e-4379-9b44-5a3a0bcc8261",
                             "name": "Session created",
                             "originalRequest": {
                                 "url": {
@@ -80,7 +357,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -102,7 +379,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 99,\n    \"key_1\": \"string\",\n    \"key_2\": 135\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -128,12 +405,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 390,\n    \"key_1\": 2980.41441608499\n  }\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6652.403264215553\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3774e29a-fe8b-4255-b613-d05dcbd46d50",
+                            "id": "c6b2908c-c346-4031-935e-9efca42a9993",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -155,7 +432,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -177,7 +454,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 99,\n    \"key_1\": \"string\",\n    \"key_2\": 135\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -203,12 +480,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "feeb56e5-c2b3-475d-b515-17aaf4cadd21",
+                            "id": "856b2dd2-5cc8-43d4-8258-71b75a111dc6",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -230,7 +507,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -252,7 +529,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 99,\n    \"key_1\": \"string\",\n    \"key_2\": 135\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -278,12 +555,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4f6f95a5-9b27-474c-b778-aa9454b8881e",
+                            "id": "54538911-c60e-4ca3-bf77-41eccd89aad2",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -305,7 +582,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -327,7 +604,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 99,\n    \"key_1\": \"string\",\n    \"key_2\": 135\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -353,12 +630,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c8aa1568-e50b-4b1e-8ce3-f3afa4d311d3",
+                            "id": "5b1e2036-2b83-414b-9e07-634a0ec6ee00",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -380,7 +657,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -402,7 +679,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 99,\n    \"key_1\": \"string\",\n    \"key_2\": 135\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -428,7 +705,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -439,7 +716,7 @@
                     }
                 },
                 {
-                    "id": "bf9c5fb8-af10-4756-8de5-96e1815dff9f",
+                    "id": "608dd1fb-f765-4c7e-8e8b-5a19ed0bfa2d",
                     "name": "Get an active session or create a new one",
                     "request": {
                         "name": "Get an active session or create a new one",
@@ -466,7 +743,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -492,7 +769,7 @@
                     },
                     "response": [
                         {
-                            "id": "bc2909e3-1c80-4b30-828c-755f41fefea6",
+                            "id": "af943ab4-cc00-41c1-9e7b-fbbe1d5d6c34",
                             "name": "Session returned (existing or new)",
                             "originalRequest": {
                                 "url": {
@@ -514,7 +791,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -562,12 +839,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": \"string\"\n  },\n  \"reused\": \"<boolean>\"\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"reused\": \"<boolean>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "308ff5ec-89e2-43ba-aada-436b0302803e",
+                            "id": "42047507-a7ce-4ebf-80b2-9a47abecd384",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -589,7 +866,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -637,12 +914,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0c08495e-8803-4ad1-9824-a46a4749fc61",
+                            "id": "dbb4de31-d088-430e-b4a1-291908ec9751",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -664,7 +941,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -712,12 +989,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "64c9c80e-c3f6-47a9-ab87-d4451661acf3",
+                            "id": "83144ce6-2cd3-407c-9149-5c523a381a47",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -739,7 +1016,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -787,12 +1064,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "07606b4f-c992-45b1-baa4-b911a5a1f7f2",
+                            "id": "44ae40f5-b9ee-4e7d-8b65-2f714d7271c7",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -814,7 +1091,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -862,7 +1139,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -879,7 +1156,7 @@
             "description": "Record fine-grained events. Preferred for HTTP clients in any language.",
             "item": [
                 {
-                    "id": "ce7c46ff-28bd-4aea-9ed6-80fd6bbc2f81",
+                    "id": "5e780c80-1b58-417f-beea-68848e7eea7a",
                     "name": "Trace an LLM call",
                     "request": {
                         "name": "Trace an LLM call",
@@ -903,7 +1180,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -917,7 +1194,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": \"string\",\n    \"key_1\": false\n  },\n  \"output\": {\n    \"key_0\": 5385,\n    \"key_1\": 4226.1758127761495\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": 4029,\n    \"key_2\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -929,7 +1206,7 @@
                     },
                     "response": [
                         {
-                            "id": "a36ca097-460f-49ed-bb62-e10669026a36",
+                            "id": "5ac787c7-ae14-430d-8062-20a53caac855",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -951,7 +1228,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -973,7 +1250,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": \"string\",\n    \"key_1\": false\n  },\n  \"output\": {\n    \"key_0\": 5385,\n    \"key_1\": 4226.1758127761495\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": 4029,\n    \"key_2\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1004,7 +1281,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8edcff1e-eda6-49ec-ba48-28151b2056c1",
+                            "id": "d779e07b-c54b-41b1-b0fc-b5c7a18eb6bf",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1026,7 +1303,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1048,7 +1325,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": \"string\",\n    \"key_1\": false\n  },\n  \"output\": {\n    \"key_0\": 5385,\n    \"key_1\": 4226.1758127761495\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": 4029,\n    \"key_2\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1074,12 +1351,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fa649e16-fd9c-402a-a43f-68ae90f769d7",
+                            "id": "842158ec-68a0-4c48-968b-75653580c2bc",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1101,7 +1378,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1123,7 +1400,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": \"string\",\n    \"key_1\": false\n  },\n  \"output\": {\n    \"key_0\": 5385,\n    \"key_1\": 4226.1758127761495\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": 4029,\n    \"key_2\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1149,12 +1426,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "54fe2d4c-ba9f-49a4-8101-c8b8310d84d3",
+                            "id": "8c449e66-eba8-4357-9163-c52d4947a54c",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1176,7 +1453,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1198,7 +1475,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": \"string\",\n    \"key_1\": false\n  },\n  \"output\": {\n    \"key_0\": 5385,\n    \"key_1\": 4226.1758127761495\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": 4029,\n    \"key_2\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1224,12 +1501,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ddbb83cf-ace1-4ea6-b6c8-4be8d6464afd",
+                            "id": "8f741b7d-2dda-4fcb-9aca-519e830383ef",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -1251,7 +1528,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1273,7 +1550,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": \"string\",\n    \"key_1\": false\n  },\n  \"output\": {\n    \"key_0\": 5385,\n    \"key_1\": 4226.1758127761495\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false,\n    \"key_1\": 4029,\n    \"key_2\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1299,7 +1576,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1310,7 +1587,7 @@
                     }
                 },
                 {
-                    "id": "f27afd27-3180-4043-ba17-5f136e2eac26",
+                    "id": "b993189f-aef8-458d-a86b-fa077d1645a3",
                     "name": "Trace a tool/function call",
                     "request": {
                         "name": "Trace a tool/function call",
@@ -1334,7 +1611,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -1348,7 +1625,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": false,\n    \"key_1\": 7321.85421826729,\n    \"key_2\": false,\n    \"key_3\": 9776.866704144324,\n    \"key_4\": 9267\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"voice\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1360,7 +1637,7 @@
                     },
                     "response": [
                         {
-                            "id": "10f1c75b-22c2-42dd-a1da-6a476bc7d765",
+                            "id": "cb9d391e-96da-4022-92f2-bc9de53d0dfe",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1382,7 +1659,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1404,7 +1681,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": false,\n    \"key_1\": 7321.85421826729,\n    \"key_2\": false,\n    \"key_3\": 9776.866704144324,\n    \"key_4\": 9267\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"voice\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1435,7 +1712,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "81f03f64-5eb0-4f4d-81f6-6dcb78be04ed",
+                            "id": "74eea1ff-33d9-4127-b274-6a7d48eecb03",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1457,7 +1734,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1479,7 +1756,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": false,\n    \"key_1\": 7321.85421826729,\n    \"key_2\": false,\n    \"key_3\": 9776.866704144324,\n    \"key_4\": 9267\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"voice\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1505,12 +1782,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5f38b947-8733-4e2f-80e6-38354cf74a4c",
+                            "id": "e331680a-8d1b-477a-9db1-b7e30d25b9e0",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1532,7 +1809,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1554,7 +1831,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": false,\n    \"key_1\": 7321.85421826729,\n    \"key_2\": false,\n    \"key_3\": 9776.866704144324,\n    \"key_4\": 9267\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"voice\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1580,12 +1857,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8853eeb1-08b3-4f0f-b452-be637cd5e0c3",
+                            "id": "66c201f5-6f2d-43f1-965b-eeb3d759cb51",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1607,7 +1884,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1629,7 +1906,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": false,\n    \"key_1\": 7321.85421826729,\n    \"key_2\": false,\n    \"key_3\": 9776.866704144324,\n    \"key_4\": 9267\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"voice\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1655,12 +1932,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c1d0fdb2-02e2-4144-9f62-2611525784f7",
+                            "id": "6c7f289b-fce3-471d-be24-3a6f32dd150c",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -1682,7 +1959,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1704,7 +1981,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": false,\n    \"key_1\": 7321.85421826729,\n    \"key_2\": false,\n    \"key_3\": 9776.866704144324,\n    \"key_4\": 9267\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"voice\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1730,7 +2007,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1741,7 +2018,7 @@
                     }
                 },
                 {
-                    "id": "a4d4a836-6ae3-4b32-8088-dc623e5ea671",
+                    "id": "e33190c2-be36-492a-a0d2-b082e6f4c90a",
                     "name": "Trace an agent-to-agent handoff",
                     "request": {
                         "name": "Trace an agent-to-agent handoff",
@@ -1765,7 +2042,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -1779,7 +2056,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 478,\n    \"key_2\": 8742.255655442248\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1791,7 +2068,7 @@
                     },
                     "response": [
                         {
-                            "id": "099754cd-75e2-4c4a-a59f-269ea12bc86b",
+                            "id": "53f5bf80-46bc-4d13-a142-3b915658b603",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1813,7 +2090,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1835,7 +2112,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 478,\n    \"key_2\": 8742.255655442248\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1866,7 +2143,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8bfd8551-2917-47cc-b1e5-6710b2ba71d9",
+                            "id": "64537411-a6ce-4229-abb3-48328e85a8c3",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1888,7 +2165,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1910,7 +2187,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 478,\n    \"key_2\": 8742.255655442248\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1936,12 +2213,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e222b98d-928b-492e-9129-4019f238b409",
+                            "id": "b5183c8b-ebaa-46ed-ae2f-674b7c09e52a",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1963,7 +2240,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1985,7 +2262,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 478,\n    \"key_2\": 8742.255655442248\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2011,12 +2288,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ae007871-b355-4c6e-a91d-d75ff0ce4ffa",
+                            "id": "842560d4-cf0e-46be-9fc5-65e52d34ae05",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2038,7 +2315,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2060,7 +2337,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 478,\n    \"key_2\": 8742.255655442248\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2086,12 +2363,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8c45a00e-86a8-40d9-861d-7c6bb248a6f1",
+                            "id": "9e23c4c6-fb21-452c-b9f6-1e4e0272037b",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -2113,7 +2390,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2135,7 +2412,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 478,\n    \"key_2\": 8742.255655442248\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2161,7 +2438,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2172,7 +2449,7 @@
                     }
                 },
                 {
-                    "id": "dc4c07f3-5a1e-4e3b-9a15-779d2fad0774",
+                    "id": "c70b520d-555d-4a2e-9d6a-f2ad0cffa53c",
                     "name": "Trace a log entry",
                     "request": {
                         "name": "Trace a log entry",
@@ -2199,7 +2476,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -2213,7 +2490,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2225,7 +2502,7 @@
                     },
                     "response": [
                         {
-                            "id": "bd608516-2ce2-4779-9ea9-f1ce1351e80b",
+                            "id": "1553b6ed-8df9-46b4-98e8-623be9d29116",
                             "name": "Log recorded",
                             "originalRequest": {
                                 "url": {
@@ -2247,7 +2524,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2269,7 +2546,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2300,7 +2577,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9edd4987-d0a5-4b10-81ac-e2d899d77bec",
+                            "id": "09cc2dee-85a1-4246-9ddb-2b6d76b9860d",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -2322,7 +2599,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2344,7 +2621,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2370,12 +2647,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c5f88bfa-de49-49e3-8953-fe7c4cad58dd",
+                            "id": "a21a847d-ae9c-42b7-a1b2-1d7c714e493f",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2397,7 +2674,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2419,7 +2696,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2445,12 +2722,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "31a4e5a6-3461-465d-b97c-776935c7247b",
+                            "id": "8ef986f5-e3c4-48cf-b4dc-86e223165b21",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2472,7 +2749,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2494,7 +2771,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2520,12 +2797,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c5f5b12c-fd3e-4725-95ad-0cf78aaf8195",
+                            "id": "4bb635c4-7522-4801-880a-d3cb4a90a283",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -2547,7 +2824,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2569,7 +2846,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2595,7 +2872,441 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "7e685794-be1e-4c7e-8fef-182ae221c478",
+                    "name": "Batch trace endpoint (mixed types)",
+                    "request": {
+                        "name": "Batch trace endpoint (mixed types)",
+                        "description": {
+                            "content": "Submit up to 100 traces in a single request. Each item carries a\n`type` field (`llm` | `tool` | `handoff` | `log`) and the same\nbody shape as the per-type endpoint, minus the `type` field.\n\n**Partial success is allowed.** When the outer envelope is\nwell-formed, the response is always `200`; per-item status is\nreported in the `results` array (`status: \"ok\"` or\n`status: \"error\"`). The outer `success` is `true` only when\nevery item succeeded.\n\nUse this whenever a single client interaction produces multiple\ntraces (an LLM call followed by a tool call, plus a log entry,\nfor example) — it cuts N round-trips down to one.\n",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "traces",
+                                "batch"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "X-Request-ID",
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                            },
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "e5b00c30-b2ad-4d0d-8806-2c63b241706d",
+                            "name": "Batch processed. Inspect `results` for per-item status.\n`failed > 0` means at least one item errored — the others\nwere still recorded.",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"llm\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5691e344-337d-43a3-89d6-1d27464f7bbf",
+                            "name": "Bad Request — required field missing or invalid payload",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "50a84e3b-e2f5-4b19-8e37-b19a8cdd8d99",
+                            "name": "Unauthorized — invalid or missing tracer token",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "ae76d54e-3b7b-4af8-8f93-9fd4c83e2243",
+                            "name": "Forbidden — token does not have access to the resource",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e1ee49b3-b033-47aa-9213-964dd9630862",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2612,7 +3323,7 @@
             "description": "Conversation records (used by the Python SDK and for batch imports).",
             "item": [
                 {
-                    "id": "03eca025-485a-46bc-aa81-9d0a19a06023",
+                    "id": "5abd9fb9-9602-4340-be21-f0d2d57d9b34",
                     "name": "Upload conversation records (batch)",
                     "request": {
                         "name": "Upload conversation records (batch)",
@@ -2639,7 +3350,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -2653,7 +3364,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9030\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2665,7 +3376,7 @@
                     },
                     "response": [
                         {
-                            "id": "d78b552c-b36c-46d7-8ff2-b7fb2a3f11aa",
+                            "id": "0d7038a1-0ee6-4403-a5e7-48646ad4c876",
                             "name": "Records processed",
                             "originalRequest": {
                                 "url": {
@@ -2687,7 +3398,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2709,7 +3420,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9030\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2735,12 +3446,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": 3511.41191581952,\n    \"key_1\": 3391.831957315208\n  }\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": 2862\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "194a7865-2305-4917-9ac4-da0c5ff7a987",
+                            "id": "d1c0cc18-8b8d-4790-9351-833ef0a79d14",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -2762,7 +3473,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2784,7 +3495,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9030\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2810,12 +3521,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2f103df4-fc12-4ef3-ba68-e466101b87d0",
+                            "id": "f259d930-e0cf-4974-866e-2ae1444819c7",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2837,7 +3548,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2859,7 +3570,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9030\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2885,12 +3596,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d1f83fe6-b35f-4c5c-b4e4-5b46b81e9313",
+                            "id": "b82efae9-0748-424b-a718-86685618c831",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2912,7 +3623,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2934,7 +3645,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9030\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2960,12 +3671,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4c8be370-9b93-4031-ad00-9f7a5e648422",
+                            "id": "2f127de0-db1a-4597-a1f2-c35b6c389348",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -2987,7 +3698,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3009,7 +3720,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9030\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3035,7 +3746,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3052,7 +3763,7 @@
             "description": "Operational log entries.",
             "item": [
                 {
-                    "id": "c4dd68dd-9a7c-45b2-b32e-6467b47d272f",
+                    "id": "777086b2-79ba-4c51-86c4-961be581631c",
                     "name": "Upload operational logs (batch)",
                     "request": {
                         "name": "Upload operational logs (batch)",
@@ -3079,7 +3790,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -3093,7 +3804,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ]\n}",
+                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -3105,7 +3816,7 @@
                     },
                     "response": [
                         {
-                            "id": "f2f4c75c-d81b-4b30-be7d-38911694d0fa",
+                            "id": "962f2d66-c025-46e5-b77c-fb7e485b6e19",
                             "name": "Logs processed",
                             "originalRequest": {
                                 "url": {
@@ -3127,7 +3838,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3149,7 +3860,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3175,12 +3886,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": 3924\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": false,\n  \"key_1\": 9938,\n  \"key_2\": 2370.641984077114\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1f8ffc45-5f36-42ef-bc66-5b3f214a72cd",
+                            "id": "75a93609-4450-4610-84f3-fb222a22b2bc",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3202,7 +3913,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3224,7 +3935,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3250,12 +3961,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "61460643-9658-4ddf-8a53-c085c56a1e69",
+                            "id": "b8730a32-1d0f-4a6c-975e-4048933bbc30",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3277,7 +3988,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3299,7 +4010,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3325,12 +4036,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8f6710a3-0e3d-49c8-9b7e-a95ae7029e25",
+                            "id": "ccb12286-6861-4f76-a0b2-31b4fd102939",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3352,7 +4063,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3374,7 +4085,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3400,12 +4111,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "888db82b-af1c-4099-b5ea-d62dc9912462",
+                            "id": "1df2637b-4115-49b6-8f81-ad480c1c6ddf",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3427,7 +4138,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3449,7 +4160,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3475,7 +4186,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3492,7 +4203,7 @@
             "description": "Read records and logs.",
             "item": [
                 {
-                    "id": "995defa7-b273-4b70-a785-06b397fbfec1",
+                    "id": "20c59a3d-82cf-4c71-bd08-207de856ccbf",
                     "name": "Query conversation records",
                     "request": {
                         "name": "Query conversation records",
@@ -3515,7 +4226,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -3541,7 +4252,7 @@
                     },
                     "response": [
                         {
-                            "id": "e23cebf1-bec9-4f89-ba06-7a5de4781526",
+                            "id": "235a86df-ee5a-4157-b6e3-87ffc15593ca",
                             "name": "Records matching the query",
                             "originalRequest": {
                                 "url": {
@@ -3562,7 +4273,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3610,12 +4321,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 505.58909362356076,\n            \"key_1\": 2723\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"slack\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\"\n          },\n          {\n            \"key_0\": 1473\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"user\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": \"string\",\n            \"key_2\": true\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 1246\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 8776.463025717552\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0f293356-b589-4c39-9f39-bb4caefe7340",
+                            "id": "24c08caf-9af6-4229-9f79-b5050a3d74b2",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3636,7 +4347,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3684,12 +4395,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d3fc22d8-fa94-4864-94a1-266e26bfbbd1",
+                            "id": "7be6cd02-a92b-4214-a7a3-8e06aefb9902",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3710,7 +4421,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3758,12 +4469,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "25022efc-a8cb-485d-b563-52163896fa63",
+                            "id": "f2b5ce81-5ec7-42ca-a109-684d4ae4dbe0",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3784,7 +4495,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3832,12 +4543,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "84d37dc5-4b64-4a90-8332-07277318df89",
+                            "id": "02fd1822-4568-4dfc-af49-90e12ce5822e",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3858,7 +4569,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3906,7 +4617,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3917,7 +4628,7 @@
                     }
                 },
                 {
-                    "id": "42237404-6495-4ac2-aee6-d9f3f7168639",
+                    "id": "17f06463-6fde-4166-8fd2-efd277d5500f",
                     "name": "Query log entries",
                     "request": {
                         "name": "Query log entries",
@@ -3941,7 +4652,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -3967,7 +4678,7 @@
                     },
                     "response": [
                         {
-                            "id": "f57c092c-dc9b-4f66-b04d-0dea15fc7cac",
+                            "id": "d6808a37-67ff-4d91-b2ca-5f91a9a1ab60",
                             "name": "Logs matching the query",
                             "originalRequest": {
                                 "url": {
@@ -3989,7 +4700,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4037,12 +4748,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 965\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 3435,\n        \"key_1\": \"string\"\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 3758.1973690649693,\n        \"key_1\": \"string\"\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "826fcb73-652a-4b2a-b3eb-1d4fe4c726a4",
+                            "id": "80782fa1-8b24-48ff-a664-5a85dc7f5bf0",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4064,7 +4775,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4112,12 +4823,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "92e280fe-976b-4777-a460-2168f8e83ded",
+                            "id": "42056d0c-d99a-40a6-8dd3-7bd2e122126f",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4139,7 +4850,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4187,12 +4898,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5d970ef5-56bf-472e-bcdd-bd2ca4ba7de8",
+                            "id": "eeee3614-98a7-4a75-8706-1c895bf4e55f",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4214,7 +4925,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4262,12 +4973,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cdff220e-1817-4b56-93dd-796c6872674e",
+                            "id": "f642b82a-1148-4da1-a43c-4e7381234e30",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -4289,7 +5000,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4337,7 +5048,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4354,7 +5065,7 @@
             "description": "Bulk export with server-side pagination.",
             "item": [
                 {
-                    "id": "0d6e29a3-f1b3-423d-9afb-8bb61cdf6924",
+                    "id": "6cd23e3d-8e1f-4bf0-8357-d68d7d545bae",
                     "name": "Export conversation records (JSON or CSV)",
                     "request": {
                         "name": "Export conversation records (JSON or CSV)",
@@ -4378,7 +5089,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -4404,7 +5115,7 @@
                     },
                     "response": [
                         {
-                            "id": "3d66bb88-9983-4429-b0a1-8ef76b3d4afe",
+                            "id": "1e585de0-db97-4975-abc1-2ea6eb94ea61",
                             "name": "Records exported",
                             "originalRequest": {
                                 "url": {
@@ -4426,7 +5137,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4474,12 +5185,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 5953,\n            \"key_1\": 6085\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"email\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 9775.965629597156,\n            \"key_1\": \"string\"\n          },\n          {\n            \"key_0\": 8517,\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 6397\n          },\n          {\n            \"key_0\": 584\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 7286,\n            \"key_1\": false\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a997da65-1261-417f-9ca7-3e36ec9e2be9",
+                            "id": "acd40db4-c223-4256-81df-f4062170344c",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4501,7 +5212,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4549,12 +5260,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "590ce015-66d4-4c94-8737-0da6192bfc97",
+                            "id": "a588e833-b273-4a46-b252-e3b63db3a9c8",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4576,7 +5287,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4624,12 +5335,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8935541e-3929-46f5-8498-8940a2d14579",
+                            "id": "79829992-9794-4b20-b352-335d34c22f21",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4651,7 +5362,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4699,12 +5410,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b9c625f9-4f26-4409-bbcf-1244f57dedc3",
+                            "id": "4b857743-8089-42b8-92ac-897785ce454a",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -4726,7 +5437,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4774,7 +5485,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4785,7 +5496,7 @@
                     }
                 },
                 {
-                    "id": "9742de2e-fe8f-4737-bb4a-7dc6ed15d838",
+                    "id": "0afa6373-d454-4a63-ab52-74283f6aa2ee",
                     "name": "Export logs (JSON or CSV)",
                     "request": {
                         "name": "Export logs (JSON or CSV)",
@@ -4809,7 +5520,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                             },
                             {
                                 "key": "Content-Type",
@@ -4823,7 +5534,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"debug\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -4835,7 +5546,7 @@
                     },
                     "response": [
                         {
-                            "id": "3f1e8c14-32bc-414b-96d6-cc72bdb13fee",
+                            "id": "0994a0b3-7bbc-4994-aef6-52139f607263",
                             "name": "Logs exported",
                             "originalRequest": {
                                 "url": {
@@ -4857,7 +5568,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4879,7 +5590,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"debug\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4905,12 +5616,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": 9088.025891254294\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": false,\n        \"key_2\": \"string\",\n        \"key_3\": 8536\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 7386.8936277919165\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 6461.955984018873,\n        \"key_1\": true\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7a14e925-c2a2-4741-9bdd-fb471eeab54c",
+                            "id": "5b6662ae-cd57-4402-b8b8-1383a7bd2113",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4932,7 +5643,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4954,7 +5665,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"debug\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4980,12 +5691,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e4b2b098-e68d-4841-8540-2da762d3ef38",
+                            "id": "d311da1b-95ea-4436-98a3-0d48b65cdf9c",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5007,7 +5718,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5029,7 +5740,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"debug\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5055,12 +5766,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "776e5bc4-88ca-43a8-a721-16c0f2d1598e",
+                            "id": "cb06a20e-afc7-44b0-a2b5-065d5255637b",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -5082,7 +5793,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5104,7 +5815,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"debug\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5130,12 +5841,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4f6d2719-551c-43fc-bac5-54c3c38da378",
+                            "id": "49951922-a797-49ad-9393-4047c7fa69ec",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5157,7 +5868,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "\"Jl}(hh/=\\>}{#P8Bw^-F+5"
+                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5179,7 +5890,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"debug\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5205,7 +5916,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"unauthorized\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5236,7 +5947,7 @@
         }
     ],
     "info": {
-        "_postman_id": "6e66d8b2-29f7-4e50-a466-bbf41c2cc729",
+        "_postman_id": "58ce2715-582f-456c-9b64-b9c71c984534",
         "name": "MonkAI Trace API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/docs/redocly.yaml
+++ b/docs/redocly.yaml
@@ -1,0 +1,9 @@
+extends:
+  - recommended
+
+rules:
+  # Health endpoints (GET / HEAD /health) legitimately have no 4xx
+  # responses — they're auth-free liveness probes that either return
+  # 200 or fail at the network level. Redocly's built-in rule wants
+  # every operation to document a 4xx, which adds noise here.
+  operation-4xx-response: off

--- a/scripts/add_code_samples.py
+++ b/scripts/add_code_samples.py
@@ -31,6 +31,16 @@ TOKEN_ENV = "MONKAI_TRACER_TOKEN"
 
 def example_payload(operation_id: str) -> str:
     """Concrete example bodies, kept short for readability."""
+    if operation_id == "healthCheck" or operation_id == "healthCheckHead":
+        return ""  # GET/HEAD, no body
+    if operation_id == "traceBatch":
+        return (
+            '{"traces":['
+            '{"type":"llm","session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"hi"}]},"output":{"content":"hello"}},'
+            '{"type":"tool","session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},'
+            '{"type":"log","session_id":"sess_abc","level":"info","message":"done"}'
+            "]}"
+        )
     if operation_id == "createSession":
         return '{"namespace":"my-agent","user_id":"5521999998888","inactivity_timeout":300}'
     if operation_id == "getOrCreateSession":
@@ -70,9 +80,12 @@ def example_payload(operation_id: str) -> str:
     return "{}"
 
 
-def curl_sample(path: str, body: str) -> str:
+def curl_sample(path: str, body: str, method: str = "POST") -> str:
+    if method in ("GET", "HEAD"):
+        flag = " -I" if method == "HEAD" else ""
+        return f"curl{flag} \"{API_BASE}{path}\"\n"
     return (
-        f"curl -X POST \"{API_BASE}{path}\" \\\n"
+        f"curl -X {method} \"{API_BASE}{path}\" \\\n"
         f"  -H \"Authorization: Bearer ${TOKEN_ENV}\" \\\n"
         f"  -H \"Content-Type: application/json\" \\\n"
         f"  -H \"X-Request-ID: $(uuidgen)\" \\\n"
@@ -80,11 +93,17 @@ def curl_sample(path: str, body: str) -> str:
     )
 
 
-def node_sample(path: str, body: str) -> str:
+def node_sample(path: str, body: str, method: str = "POST") -> str:
+    if method in ("GET", "HEAD"):
+        return (
+            "// Node.js 18+ — no dependencies, no auth required\n"
+            f"const res = await fetch(\"{API_BASE}{path}\", {{ method: \"{method}\" }});\n"
+            "console.log(res.status, res.headers.get(\"x-request-id\"));\n"
+        )
     return (
         "// Node.js 18+ — no dependencies\n"
         f"const res = await fetch(\"{API_BASE}{path}\", {{\n"
-        "  method: \"POST\",\n"
+        f"  method: \"{method}\",\n"
         "  headers: {\n"
         f"    \"Authorization\": `Bearer ${{process.env.{TOKEN_ENV}}}`,\n"
         "    \"Content-Type\": \"application/json\"\n"
@@ -95,7 +114,14 @@ def node_sample(path: str, body: str) -> str:
     )
 
 
-def python_sample(path: str, body: str) -> str:
+def python_sample(path: str, body: str, method: str = "POST") -> str:
+    if method in ("GET", "HEAD"):
+        verb = method.lower()
+        return (
+            "import requests\n"
+            f"r = requests.{verb}(\"{API_BASE}{path}\")\n"
+            "print(r.status_code, r.headers[\"x-request-id\"])\n"
+        )
     return (
         "import os, requests\n"
         f"r = requests.post(\n"
@@ -107,12 +133,12 @@ def python_sample(path: str, body: str) -> str:
     )
 
 
-def build_code_samples(path: str, operation_id: str) -> list[dict]:
+def build_code_samples(path: str, operation_id: str, method: str = "POST") -> list[dict]:
     body = example_payload(operation_id)
     return [
-        {"lang": "Shell", "label": "curl", "source": LiteralScalarString(curl_sample(path, body))},
-        {"lang": "JavaScript", "label": "Node.js", "source": LiteralScalarString(node_sample(path, body))},
-        {"lang": "Python", "label": "Python", "source": LiteralScalarString(python_sample(path, body))},
+        {"lang": "Shell", "label": "curl", "source": LiteralScalarString(curl_sample(path, body, method))},
+        {"lang": "JavaScript", "label": "Node.js", "source": LiteralScalarString(node_sample(path, body, method))},
+        {"lang": "Python", "label": "Python", "source": LiteralScalarString(python_sample(path, body, method))},
     ]
 
 
@@ -134,7 +160,13 @@ def main() -> int:
         for method, op in item.items():
             if not isinstance(op, dict) or "operationId" not in op:
                 continue
-            op["x-codeSamples"] = build_code_samples(path, op["operationId"])
+            # Skip HEAD operations — same semantics as GET, code samples
+            # would be redundant. ReDoc renders HEAD without samples cleanly.
+            if method.lower() == "head":
+                continue
+            op["x-codeSamples"] = build_code_samples(
+                path, op["operationId"], method=method.upper()
+            )
             touched += 1
 
     with spec_path.open("w") as f:


### PR DESCRIPTION
## O que foi feito

Companion docs do que ja esta deployado em prod (monkai-api v142):
- v141: \`GET /v1/health\` ([BeMonkAI/monkai-agent-hub#22](https://github.com/BeMonkAI/monkai-agent-hub/pull/22))
- v142: \`POST /v1/traces/batch\` ([BeMonkAI/monkai-agent-hub#23](https://github.com/BeMonkAI/monkai-agent-hub/pull/23))

### \`docs/openapi.yaml\`
- Nova tag **Health**
- Novo path \`/health\` com \`GET\` + \`HEAD\` (sem auth via \`security: []\`)
- Novo path \`/traces/batch\` com \`traceBatch\`, tipado via \`BatchTraceRequest\`/\`BatchTraceResponse\` e \`BatchTraceItem\` discriminado (oneOf llm/tool/handoff/log) — generators TS pegam tagged union limpa
- \`x-codeSamples\` regenerado em todas as 14 ops (curl/Node/Python). Health samples sem auth; HEAD pulado (mesma semantica do GET)

### \`docs/http_rest_api.md\`
- Nova secao **Health Check** no topo de Endpoints
- Nova secao **Batch Traces** com exemplo completo, contrato de partial-success, limites, curl

### \`docs/API_CHANGELOG.md\`
- Nova entry \`[v1.2] — 2026-05-02\` com health + batch
- \"Planned (Phase 3)\" agora so tem 2 items: idempotency + rate-limit

### \`docs/postman_collection.json\`
- Regenerado: **7 folders / 15 requests** (era 6/12)

### Configs/scripts
- **Novo** \`docs/redocly.yaml\` — turns off \`operation-4xx-response\` so health endpoints (legitimamente sem 4xx surface) nao geram warnings
- \`.github/workflows/openapi-lint.yml\` passa o novo config
- \`scripts/add_code_samples.py\` agora aceita \`method\` e skipa HEAD; emite no-body samples pra GET/HEAD

## Como testar

\`\`\`bash
.venv/bin/python -c \"from openapi_spec_validator import validate; import yaml; validate(yaml.safe_load(open('docs/openapi.yaml')))\"
npx --yes @redocly/cli@latest lint docs/openapi.yaml --config docs/redocly.yaml

# Smoke contra prod (versao 142):
curl https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/health | python3 -m json.tool
\`\`\`

## Checklist

- [x] OpenAPI 3.1 valido (14 paths, 41 schemas)
- [x] Redocly lint zero warnings (com config novo)
- [x] Postman regenerado (7/15)
- [x] Mudanca 100% docs (zero codigo runtime)
- [x] Reflete prod (monkai-api v142)
- [x] Site GitHub Pages (\`bemonkai.github.io/monkai-trace/\`) vai picar mudancas no merge

## Proximos passos pra fechar Fase 3

- \`Idempotency-Key\` em \`/traces/*\` e \`/traces/batch\` (precisa tabela DB)
- Rate-limit response headers (precisa contador)

Refs #12