### PR TITLE
docs(api): Idempotency-Key (companion to monkai-hub#25)

### DIFF
--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -13,11 +13,41 @@ keep working during a deprecation window.
 ## [Unreleased]
 
 ### Planned (Phase 3 — remaining)
-- `Idempotency-Key` header for `POST /traces/*` and `POST /v1/traces/batch`.
 - Rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
 
 ### Planned (Phase 2 — remaining)
 - Custom domain `https://api.monkai.ai/trace/v1`.
+
+## [v1.3] — 2026-05-02
+
+### Added
+- **`Idempotency-Key` request header** on `POST /v1/traces/llm`,
+  `/v1/traces/tool`, `/v1/traces/handoff`, `/v1/traces/log`, and
+  `/v1/traces/batch`. Same key + identical body within 24h → cached
+  replay (no DB inserts, no token charges). Same key + different body
+  → `422 idempotency_key_conflict`. Different/missing key → fresh
+  execution. References:
+  [BeMonkAI/monkai-agent-hub#25](https://github.com/BeMonkAI/monkai-agent-hub/pull/25)
+  (edge function + migration) and
+  [`docs/MIGRATION.md`](./MIGRATION.md#5-safe-retries-with-idempotency-key)
+  (client adoption guide).
+- **`Idempotency-Replay`** response header (`"true"` only) on cached
+  replays.
+- **`Idempotency-Original-Request-ID`** response header on cached
+  replays — mirrors the `X-Request-ID` of the first call so logs can
+  be correlated across retries.
+- New canonical error code: **`idempotency_key_conflict`**
+  (HTTP 422). Listed in the OpenAPI `Error` schema enum.
+
+### Notes
+- Errors are **not** cached. Retrying a failed call with the same key
+  naturally re-executes — no risk of getting "stuck" replaying a
+  transient failure.
+- Cache failures (DB unavailable) are degraded to a miss: the request
+  proceeds normally without idempotency protection, with a warning
+  logged server-side. Idempotency is never a single point of failure.
+- Storage: per-tenant Postgres table `monkai_idempotency_keys` with
+  24h retention via `expires_at`. RLS-locked, service-role only.
 
 ## [v1.2] — 2026-05-02
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -251,6 +251,91 @@ and `request_id`. Treat the extra fields as documented per endpoint.
 
 ---
 
+## 5. Safe retries with `Idempotency-Key`
+
+This is **opt-in** and purely additive — clients that don't send the
+header keep the pre-Phase-3 behaviour. Strongly recommended for any
+production code that retries.
+
+### Behaviour
+
+Trace endpoints (`/v1/traces/llm`, `/tool`, `/handoff`, `/log`,
+`/traces/batch`) accept an `Idempotency-Key` request header. The
+server caches the response under `(tenant, key)` for 24h:
+
+| Same key + same body | Same key + different body | Different / missing key |
+|---|---|---|
+| Cached replay (no DB inserts, no token charges) with `Idempotency-Replay: true` | `422 idempotency_key_conflict` | Fresh execution |
+
+Errors are **not** cached, so retrying a failed call with the same
+key naturally re-executes.
+
+### Recommended client pattern
+
+Generate one UUID per **logical operation** and reuse it across all
+retries of that operation:
+
+```javascript
+async function trackOnce(makeRequest) {
+  const opId = crypto.randomUUID();          // generated once
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      return await makeRequest({ "Idempotency-Key": opId });
+    } catch (err) {
+      if (err.transient && attempt < 3) continue;
+      throw err;
+    }
+  }
+}
+```
+
+The first attempt records the response; if the network drops between
+the server writing the DB and the client reading the body, retry
+attempts replay the same response — the trace is never duplicated
+and credits are never double-charged.
+
+### Reading the replay headers
+
+```javascript
+const res = await fetch(url, {
+  headers: { "Authorization": `Bearer ${token}`, "Idempotency-Key": opId },
+  ...
+});
+
+if (res.headers.get("Idempotency-Replay") === "true") {
+  console.log(
+    "Replayed result of original request",
+    res.headers.get("Idempotency-Original-Request-ID"),
+  );
+}
+```
+
+### Conflict handling
+
+If you reuse a key with a different body, the server returns
+`422 idempotency_key_conflict`. The fix is to pick a new key (or
+fix the body so it matches the original):
+
+```diff
+- // BUG: same key, body changed across retries
+- await fetch(url, { headers: { "Idempotency-Key": "static-key" }, body: latestBody });
++ const opId = crypto.randomUUID();
++ await fetch(url, { headers: { "Idempotency-Key": opId }, body: latestBody });
+```
+
+### Endpoints supported
+
+| Endpoint | Idempotency support |
+|---|---|
+| `POST /v1/traces/llm` | ✅ |
+| `POST /v1/traces/tool` | ✅ |
+| `POST /v1/traces/handoff` | ✅ |
+| `POST /v1/traces/log` | ✅ |
+| `POST /v1/traces/batch` | ✅ |
+| Other endpoints | Not yet — body-level dedup applies on bulk uploads |
+
+---
+
 ## Summary table
 
 | Change | Action | Required by |
@@ -259,6 +344,7 @@ and `request_id`. Treat the extra fields as documented per endpoint.
 | Auth → `Bearer` | Replace one header | Optional, recommended |
 | `X-Request-ID` | Generate per call, log on errors | Optional, recommended for prod |
 | Error shape | Read `error.message` and `error.code` | Required if you rendered `error` as a string |
+| `Idempotency-Key` | Generate per logical operation, reuse across retries | Optional, recommended for prod |
 
 ---
 

--- a/docs/http_rest_api.md
+++ b/docs/http_rest_api.md
@@ -57,6 +57,56 @@ curl -i -H "Authorization: Bearer tk_YOUR_TOKEN" \
 #   x-request-id: my-trace-1
 ```
 
+## Idempotency — `Idempotency-Key`
+
+Trace endpoints (`/v1/traces/llm`, `/tool`, `/handoff`, `/log`,
+`/traces/batch`) accept an optional **`Idempotency-Key`** request
+header so retries are safe.
+
+### Behaviour
+
+| Same key + same body | Same key + different body | Different/missing key |
+|---|---|---|
+| **Cached replay** — response body and status returned without re-running side effects (DB inserts, token charges). Carries `Idempotency-Replay: true`. | **`422 idempotency_key_conflict`** — pick a new key or fix the body. | **Fresh execution** (default behaviour, no caching). |
+
+The cache lives **24h** per `(tenant, key)` pair. Errors are **not**
+cached: a retry after a failure naturally re-executes.
+
+### Recommended pattern
+
+Generate one UUID per logical client operation and pass it on every
+retry of that operation:
+
+```javascript
+const opId = crypto.randomUUID();          // generated once per operation
+async function uploadTrace(body) {
+  return await postWithRetry("/v1/traces/llm", body, {
+    headers: { "Idempotency-Key": opId },
+  });
+}
+```
+
+### Replay headers
+
+When the response is served from cache, the server adds:
+
+```
+Idempotency-Replay: true
+Idempotency-Original-Request-ID: <uuid of the first request>
+```
+
+Use `Idempotency-Original-Request-ID` to find the first call in
+server logs.
+
+### Format constraints
+
+- Length: 1–128 printable ASCII characters
+- No leading whitespace
+- Same charset as `X-Request-ID`
+
+UUIDs, ULIDs, snowflakes, hex strings, or any human-friendly trace ID
+all work.
+
 ## User Identification
 
 All trace endpoints support optional user identification fields to track who is interacting with your agent:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -274,6 +274,8 @@ paths:
       operationId: traceLlmCall
       parameters:
         - $ref: "#/components/parameters/RequestIdHeader"
+        - &id001
+          $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -286,6 +288,10 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            Idempotency-Replay:
+              $ref: '#/components/headers/IdempotencyReplay'
+            Idempotency-Original-Request-ID:
+              $ref: '#/components/headers/IdempotencyOriginalRequestId'
           content:
             application/json:
               schema:
@@ -299,6 +305,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '422':
+          $ref: '#/components/responses/Conflict'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -338,6 +346,7 @@ paths:
       operationId: traceToolCall
       parameters:
         - $ref: "#/components/parameters/RequestIdHeader"
+        - *id001
       requestBody:
         required: true
         content:
@@ -350,6 +359,10 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            Idempotency-Replay:
+              $ref: '#/components/headers/IdempotencyReplay'
+            Idempotency-Original-Request-ID:
+              $ref: '#/components/headers/IdempotencyOriginalRequestId'
           content:
             application/json:
               schema:
@@ -363,6 +376,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '422':
+          $ref: '#/components/responses/Conflict'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -402,6 +417,7 @@ paths:
       operationId: traceHandoff
       parameters:
         - $ref: "#/components/parameters/RequestIdHeader"
+        - *id001
       requestBody:
         required: true
         content:
@@ -414,6 +430,10 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            Idempotency-Replay:
+              $ref: '#/components/headers/IdempotencyReplay'
+            Idempotency-Original-Request-ID:
+              $ref: '#/components/headers/IdempotencyOriginalRequestId'
           content:
             application/json:
               schema:
@@ -427,6 +447,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '422':
+          $ref: '#/components/responses/Conflict'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -468,6 +490,7 @@ paths:
       operationId: traceLog
       parameters:
         - $ref: "#/components/parameters/RequestIdHeader"
+        - *id001
       requestBody:
         required: true
         content:
@@ -480,6 +503,10 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            Idempotency-Replay:
+              $ref: '#/components/headers/IdempotencyReplay'
+            Idempotency-Original-Request-ID:
+              $ref: '#/components/headers/IdempotencyOriginalRequestId'
           content:
             application/json:
               schema:
@@ -496,6 +523,8 @@ paths:
   # ============================================================
   # RECORDS (bulk — used by Python SDK)
   # ============================================================
+        '422':
+          $ref: '#/components/responses/Conflict'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -549,6 +578,7 @@ paths:
       operationId: traceBatch
       parameters:
         - $ref: "#/components/parameters/RequestIdHeader"
+        - *id001
       requestBody:
         required: true
         content:
@@ -564,6 +594,10 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            Idempotency-Replay:
+              $ref: '#/components/headers/IdempotencyReplay'
+            Idempotency-Original-Request-ID:
+              $ref: '#/components/headers/IdempotencyOriginalRequestId'
           content:
             application/json:
               schema:
@@ -577,6 +611,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '422':
+          $ref: '#/components/responses/Conflict'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -1049,6 +1085,35 @@ components:
         header (round-trip). If omitted, the server generates a UUIDv4.
         Useful for distributed traces and support correlation.
 
+    IdempotencyKeyHeader:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema:
+        type: string
+        maxLength: 128
+        pattern: '^[\x21-\x7E][\x20-\x7E]{0,127}$'
+      description: |
+        Optional client-supplied idempotency token (Phase 3). When
+        present, the server caches the response under
+        `(tenant, key)` for **24 hours**:
+
+        - Same key + identical body → cached replay; the response
+          is returned without re-running side effects (DB inserts,
+          token charges). Replays carry `Idempotency-Replay: true`.
+        - Same key + different body → `422 idempotency_key_conflict`.
+        - Different (or missing) key → fresh execution, default
+          behaviour.
+
+        Typical pattern: generate a UUID per logical client operation
+        and pass it on every retry of that operation. Errors are NOT
+        cached, so retrying a failed call with the same key naturally
+        re-executes.
+
+        Supported on `/v1/traces/llm`, `/v1/traces/tool`,
+        `/v1/traces/handoff`, `/v1/traces/log`, and
+        `/v1/traces/batch`.
+
   headers:
     XRequestId:
       schema:
@@ -1058,6 +1123,23 @@ components:
         `X-Request-ID` header when present, otherwise a server-generated
         UUIDv4. Always emitted on every response (200, 4xx, 5xx). Quote
         this value when reporting issues.
+
+    IdempotencyReplay:
+      schema:
+        type: string
+        enum: ["true"]
+      description: |
+        Present and set to `"true"` only when the response was served
+        from the idempotency cache (same key + same body as a
+        previous request within 24h). Absent on fresh executions.
+
+    IdempotencyOriginalRequestId:
+      schema:
+        type: string
+      description: |
+        On a replay, mirrors the `X-Request-ID` of the **original**
+        request whose result is being returned. Use it to find the
+        first request in server logs.
 
   responses:
     BadRequest:
@@ -1080,6 +1162,18 @@ components:
             $ref: "#/components/schemas/Error"
     Forbidden:
       description: Forbidden — token does not have access to the resource
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestId"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Conflict:
+      description: |
+        Conflict — typically `idempotency_key_conflict`, raised when an
+        `Idempotency-Key` is reused with a different request body. Pick
+        a new key or fix the body.
       headers:
         X-Request-ID:
           $ref: "#/components/headers/XRequestId"
@@ -1293,6 +1387,7 @@ components:
                 - internal_error
                 - encryption_error
                 - anonymization_error
+                - idempotency_key_conflict
               example: missing_token
             message:
               type: string

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -5,7 +5,7 @@
             "description": "Liveness check (no auth required).",
             "item": [
                 {
-                    "id": "2ef8498d-68f4-434c-a5bd-3229f63320f7",
+                    "id": "54a13ce2-95ae-4e9b-8826-5593aa704b58",
                     "name": "Liveness check",
                     "request": {
                         "name": "Liveness check",
@@ -35,7 +35,7 @@
                     },
                     "response": [
                         {
-                            "id": "e5b5c077-4642-405f-902a-104766c71103",
+                            "id": "0c84c76f-4fae-430d-ab76-30b96d90d1e4",
                             "name": "Service is responsive",
                             "originalRequest": {
                                 "url": {
@@ -87,7 +87,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5fc57067-51de-4a0c-a284-3b9eedc7abbb",
+                            "id": "b03ba9fb-c1de-4d91-be5e-889ac43065e7",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -134,7 +134,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -145,7 +145,7 @@
                     }
                 },
                 {
-                    "id": "f04962f8-9c8b-4d76-ad19-131fc824b2d0",
+                    "id": "cd177283-a115-47b3-abb9-4c5f5e474e34",
                     "name": "Liveness check (HEAD variant)",
                     "request": {
                         "name": "Liveness check (HEAD variant)",
@@ -175,7 +175,7 @@
                     },
                     "response": [
                         {
-                            "id": "03f18fe3-2216-4fdc-88cc-967e280dbb2f",
+                            "id": "ecaac1c5-49e2-4f5e-8f1d-c2151dfe847c",
                             "name": "Service is responsive (no body)",
                             "originalRequest": {
                                 "url": {
@@ -218,7 +218,7 @@
                             "_postman_previewlanguage": "text"
                         },
                         {
-                            "id": "e226f1a0-8761-4649-8a37-9b10857bf5c9",
+                            "id": "8bfa6ded-3a8f-4034-8aa2-0c081d8b3e64",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -265,7 +265,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -282,7 +282,7 @@
             "description": "Manage conversation sessions.",
             "item": [
                 {
-                    "id": "3ebb1a79-20ba-4fac-9ef3-20e791a2ee6f",
+                    "id": "8c095856-b36b-4c28-be64-82df2abee3ee",
                     "name": "Create a new session",
                     "request": {
                         "name": "Create a new session",
@@ -309,7 +309,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -323,7 +323,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -335,7 +335,7 @@
                     },
                     "response": [
                         {
-                            "id": "c0b81a27-b26e-4379-9b44-5a3a0bcc8261",
+                            "id": "0e039b39-50e6-4591-9dcd-b3e505812c58",
                             "name": "Session created",
                             "originalRequest": {
                                 "url": {
@@ -357,7 +357,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -379,7 +379,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -405,12 +405,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6652.403264215553\n  }\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c6b2908c-c346-4031-935e-9efca42a9993",
+                            "id": "3e0ba237-44d2-4cc9-bece-0f4d122fce63",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -432,7 +432,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -454,7 +454,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -480,12 +480,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "856b2dd2-5cc8-43d4-8258-71b75a111dc6",
+                            "id": "bb2ee349-f96d-4c08-bd5c-68ffb8bec337",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -507,7 +507,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -529,7 +529,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -555,12 +555,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "54538911-c60e-4ca3-bf77-41eccd89aad2",
+                            "id": "c6a8251c-e261-4fba-9ce0-6793650a062d",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -582,7 +582,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -604,7 +604,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -630,12 +630,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5b1e2036-2b83-414b-9e07-634a0ec6ee00",
+                            "id": "63740a93-f9a8-449a-8ee4-e4f31701c0b0",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -657,7 +657,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -679,7 +679,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -705,7 +705,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -716,7 +716,7 @@
                     }
                 },
                 {
-                    "id": "608dd1fb-f765-4c7e-8e8b-5a19ed0bfa2d",
+                    "id": "4f5bd6a4-b201-49d6-a490-9707834c2382",
                     "name": "Get an active session or create a new one",
                     "request": {
                         "name": "Get an active session or create a new one",
@@ -743,7 +743,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -769,7 +769,7 @@
                     },
                     "response": [
                         {
-                            "id": "af943ab4-cc00-41c1-9e7b-fbbe1d5d6c34",
+                            "id": "a2a1822d-055f-4b32-b369-e39bff6ff9d9",
                             "name": "Session returned (existing or new)",
                             "originalRequest": {
                                 "url": {
@@ -791,7 +791,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -839,12 +839,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"reused\": \"<boolean>\"\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"reused\": \"<boolean>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "42047507-a7ce-4ebf-80b2-9a47abecd384",
+                            "id": "cf914e2d-3ccb-4cd3-bdde-462affe5dbd5",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -866,7 +866,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -914,12 +914,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "dbb4de31-d088-430e-b4a1-291908ec9751",
+                            "id": "2944e687-c514-4ac9-b962-453be5c66002",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -941,7 +941,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -989,12 +989,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "83144ce6-2cd3-407c-9149-5c523a381a47",
+                            "id": "4222508d-1e86-4472-bd31-f2ba0bd0faa2",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1016,7 +1016,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1064,12 +1064,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "44ae40f5-b9ee-4e7d-8b65-2f714d7271c7",
+                            "id": "3615ad03-64ac-43db-8b82-f8541aae209f",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -1091,7 +1091,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1139,7 +1139,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1156,7 +1156,7 @@
             "description": "Record fine-grained events. Preferred for HTTP clients in any language.",
             "item": [
                 {
-                    "id": "5e780c80-1b58-417f-beea-68848e7eea7a",
+                    "id": "aedb2203-2657-467c-9537-e553285191c1",
                     "name": "Trace an LLM call",
                     "request": {
                         "name": "Trace an LLM call",
@@ -1180,7 +1180,16 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
+                            },
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "Idempotency-Key",
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -1194,7 +1203,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1206,7 +1215,7 @@
                     },
                     "response": [
                         {
-                            "id": "5ac787c7-ae14-430d-8062-20a53caac855",
+                            "id": "e8820590-aa12-4555-be6e-9d0474f6907f",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1228,7 +1237,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1250,7 +1268,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1274,6 +1292,24 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Replay",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Original-Request-ID",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"tokens\": {\n    \"input\": \"<integer>\",\n    \"output\": \"<integer>\"\n  }\n}",
@@ -1281,7 +1317,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d779e07b-c54b-41b1-b0fc-b5c7a18eb6bf",
+                            "id": "67b7e23e-857c-4af3-bf3b-12845593b647",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1303,7 +1339,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1325,7 +1370,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1351,12 +1396,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "842158ec-68a0-4c48-968b-75653580c2bc",
+                            "id": "3b9ccc5d-7501-4a59-8353-ec68d9bd1f83",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1378,7 +1423,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1400,7 +1454,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1426,12 +1480,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8c449e66-eba8-4357-9163-c52d4947a54c",
+                            "id": "970be5e0-ea3a-4942-ba89-4cf3c68ae581",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1453,7 +1507,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1475,7 +1538,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1501,13 +1564,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8f741b7d-2dda-4fcb-9aca-519e830383ef",
-                            "name": "Internal Server Error",
+                            "id": "765cb301-53bd-4989-9900-aac5de44c6ea",
+                            "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -1528,7 +1591,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1550,7 +1622,91 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": false,\n    \"key_1\": true\n  },\n  \"output\": {\n    \"key_0\": 2107.952888474275,\n    \"key_1\": 5990.168426004865,\n    \"key_2\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 1627\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+                            "code": 422,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "0f01164f-a0e8-42b5-8a43-5aa81c39bcba",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1576,7 +1732,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1587,7 +1743,7 @@
                     }
                 },
                 {
-                    "id": "b993189f-aef8-458d-a86b-fa077d1645a3",
+                    "id": "c394ae39-7fff-4bd6-81af-752649989e38",
                     "name": "Trace a tool/function call",
                     "request": {
                         "name": "Trace a tool/function call",
@@ -1611,7 +1767,16 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
+                            },
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "Idempotency-Key",
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -1625,7 +1790,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1637,7 +1802,7 @@
                     },
                     "response": [
                         {
-                            "id": "cb9d391e-96da-4022-92f2-bc9de53d0dfe",
+                            "id": "3de35413-8090-4e0c-ad25-c1519c291e85",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1659,7 +1824,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1681,7 +1855,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1705,6 +1879,24 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Replay",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Original-Request-ID",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"tool_name\": \"<string>\"\n}",
@@ -1712,7 +1904,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "74eea1ff-33d9-4127-b274-6a7d48eecb03",
+                            "id": "77ba1104-80a9-42f2-9287-64ae2220dd7d",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1734,7 +1926,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1756,7 +1957,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1782,12 +1983,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e331680a-8d1b-477a-9db1-b7e30d25b9e0",
+                            "id": "d56ab5ef-d83d-483b-84dc-49bb40068810",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1809,7 +2010,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1831,7 +2041,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1857,12 +2067,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "66c201f5-6f2d-43f1-965b-eeb3d759cb51",
+                            "id": "a3a4d098-f9c9-42f2-be50-7f209bb884fc",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1884,7 +2094,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1906,7 +2125,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1932,13 +2151,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6c7f289b-fce3-471d-be24-3a6f32dd150c",
-                            "name": "Internal Server Error",
+                            "id": "81e79372-7a68-4b0a-8e62-deac6eb8505b",
+                            "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -1959,7 +2178,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1981,7 +2209,91 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": \"string\"\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 2426,\n    \"key_1\": 2038\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+                            "code": 422,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "092c4a11-3985-46a6-bd38-318b4828e6c0",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2007,7 +2319,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2018,7 +2330,7 @@
                     }
                 },
                 {
-                    "id": "e33190c2-be36-492a-a0d2-b082e6f4c90a",
+                    "id": "8e9746ea-3358-4d01-b04c-b478ffc0cd63",
                     "name": "Trace an agent-to-agent handoff",
                     "request": {
                         "name": "Trace an agent-to-agent handoff",
@@ -2042,7 +2354,16 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
+                            },
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "Idempotency-Key",
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -2056,7 +2377,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2068,7 +2389,7 @@
                     },
                     "response": [
                         {
-                            "id": "53f5bf80-46bc-4d13-a142-3b915658b603",
+                            "id": "a48301ef-34fd-4142-a317-fc322dc1d260",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -2090,7 +2411,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2112,7 +2442,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2136,6 +2466,24 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Replay",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Original-Request-ID",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"from\": \"<string>\",\n  \"to\": \"<string>\"\n}",
@@ -2143,7 +2491,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "64537411-a6ce-4229-abb3-48328e85a8c3",
+                            "id": "469c58cc-7462-4b84-855b-aeba21e7cfb9",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -2165,7 +2513,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2187,7 +2544,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2213,12 +2570,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b5183c8b-ebaa-46ed-ae2f-674b7c09e52a",
+                            "id": "fe523586-dd90-4d0d-a29c-bdb0cf97d1dd",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2240,7 +2597,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2262,7 +2628,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2288,12 +2654,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "842560d4-cf0e-46be-9fc5-65e52d34ae05",
+                            "id": "4789a016-b157-46fd-927d-ecc7273b9235",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2315,7 +2681,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2337,7 +2712,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2363,13 +2738,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9e23c4c6-fb21-452c-b9f6-1e4e0272037b",
-                            "name": "Internal Server Error",
+                            "id": "1951db7d-1f9c-42f4-b273-b8c573bdbcfd",
+                            "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -2390,7 +2765,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2412,7 +2796,91 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 8935.170144420088\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+                            "code": 422,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6b4f6b57-8edb-4d77-b337-fa7e3c060556",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2438,7 +2906,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2449,7 +2917,7 @@
                     }
                 },
                 {
-                    "id": "c70b520d-555d-4a2e-9d6a-f2ad0cffa53c",
+                    "id": "abc8b491-3208-4b66-9a02-e41e3b7b1c6b",
                     "name": "Trace a log entry",
                     "request": {
                         "name": "Trace a log entry",
@@ -2476,7 +2944,16 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
+                            },
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "Idempotency-Key",
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -2490,7 +2967,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2502,7 +2979,7 @@
                     },
                     "response": [
                         {
-                            "id": "1553b6ed-8df9-46b4-98e8-623be9d29116",
+                            "id": "1c68aeeb-1fd7-4065-9cfc-91163649d197",
                             "name": "Log recorded",
                             "originalRequest": {
                                 "url": {
@@ -2524,7 +3001,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2546,7 +3032,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2570,6 +3056,24 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Replay",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Original-Request-ID",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\"\n}",
@@ -2577,7 +3081,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "09cc2dee-85a1-4246-9ddb-2b6d76b9860d",
+                            "id": "55852152-598e-42ee-af73-4136a3d27c74",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -2599,7 +3103,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2621,7 +3134,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2647,12 +3160,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a21a847d-ae9c-42b7-a1b2-1d7c714e493f",
+                            "id": "cbae8323-a681-4568-bed4-06b1921262aa",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2674,7 +3187,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2696,7 +3218,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2722,12 +3244,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8ef986f5-e3c4-48cf-b4dc-86e223165b21",
+                            "id": "7ebbefe4-0190-45b0-9a72-8d188c60204e",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2749,7 +3271,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2771,7 +3302,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2797,13 +3328,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4bb635c4-7522-4801-880a-d3cb4a90a283",
-                            "name": "Internal Server Error",
+                            "id": "384df147-2da7-4843-93e4-8604eec766a1",
+                            "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -2824,7 +3355,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2846,7 +3386,91 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 769\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+                            "code": 422,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "70989e7a-4227-4457-9254-0578c3089088",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2872,7 +3496,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2883,7 +3507,7 @@
                     }
                 },
                 {
-                    "id": "7e685794-be1e-4c7e-8fef-182ae221c478",
+                    "id": "700e226e-93f2-422c-806b-dfe398555f34",
                     "name": "Batch trace endpoint (mixed types)",
                     "request": {
                         "name": "Batch trace endpoint (mixed types)",
@@ -2910,7 +3534,16 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
+                            },
+                            {
+                                "disabled": false,
+                                "description": {
+                                    "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                    "type": "text/plain"
+                                },
+                                "key": "Idempotency-Key",
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -2924,7 +3557,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2936,7 +3569,7 @@
                     },
                     "response": [
                         {
-                            "id": "e5b00c30-b2ad-4d0d-8806-2c63b241706d",
+                            "id": "fdcbae1c-ec0e-4b3c-974a-f5fab4f9f9d0",
                             "name": "Batch processed. Inspect `results` for per-item status.\n`failed > 0` means at least one item errored — the others\nwere still recorded.",
                             "originalRequest": {
                                 "url": {
@@ -2958,7 +3591,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2980,7 +3622,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3004,14 +3646,32 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Replay",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Idempotency-Original-Request-ID",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"llm\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"error\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"tool\",\n      \"status\": \"error\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5691e344-337d-43a3-89d6-1d27464f7bbf",
+                            "id": "0409ebda-977c-4a27-bb35-0022cc7d30d8",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3033,7 +3693,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3055,7 +3724,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3081,12 +3750,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "50a84e3b-e2f5-4b19-8e37-b19a8cdd8d99",
+                            "id": "79603fc9-19f6-4b59-abe3-9a9dcd45d8e1",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3108,7 +3777,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3130,7 +3808,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3156,12 +3834,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ae76d54e-3b7b-4af8-8f93-9fd4c83e2243",
+                            "id": "85fff81d-8b08-4db2-9125-b3777ecc4248",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3183,7 +3861,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3205,7 +3892,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3231,13 +3918,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e1ee49b3-b033-47aa-9213-964dd9630862",
-                            "name": "Internal Server Error",
+                            "id": "f1254907-2e72-4d39-a1af-770ca594f79b",
+                            "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -3258,7 +3945,16 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3280,7 +3976,91 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1303.1381141951592,\n        \"key_1\": false\n      },\n      \"output\": {\n        \"key_0\": true,\n        \"key_1\": true,\n        \"key_2\": 294.14980578163494\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 4971,\n        \"key_1\": 5358\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unprocessable Entity (WebDAV) (RFC 4918)",
+                            "code": 422,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "8bd6efb0-b51c-4c91-b767-b3881b7eeeef",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "8fyH3t[\"EOGhh"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3306,7 +4086,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3323,7 +4103,7 @@
             "description": "Conversation records (used by the Python SDK and for batch imports).",
             "item": [
                 {
-                    "id": "5abd9fb9-9602-4340-be21-f0d2d57d9b34",
+                    "id": "bec9311f-08fb-438d-be0f-a5fb22efd9ec",
                     "name": "Upload conversation records (batch)",
                     "request": {
                         "name": "Upload conversation records (batch)",
@@ -3350,7 +4130,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -3364,7 +4144,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -3376,7 +4156,7 @@
                     },
                     "response": [
                         {
-                            "id": "0d7038a1-0ee6-4403-a5e7-48646ad4c876",
+                            "id": "160d41f4-638d-436d-bc8b-9735e2a55fca",
                             "name": "Records processed",
                             "originalRequest": {
                                 "url": {
@@ -3398,7 +4178,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3420,7 +4200,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3446,12 +4226,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": 2862\n  }\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": true,\n    \"key_1\": 4267,\n    \"key_2\": 3226.573465335095\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d1c0cc18-8b8d-4790-9351-833ef0a79d14",
+                            "id": "71ce5644-edf8-400d-b18d-9fd9c3ac5518",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3473,7 +4253,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3495,7 +4275,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3521,12 +4301,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f259d930-e0cf-4974-866e-2ae1444819c7",
+                            "id": "ca55f206-769b-4b30-8b4b-493c6ab44f4d",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3548,7 +4328,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3570,7 +4350,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3596,12 +4376,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b82efae9-0748-424b-a718-86685618c831",
+                            "id": "c17f5237-fc2c-425d-9877-6dee12d45a3c",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3623,7 +4403,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3645,7 +4425,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3671,12 +4451,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2f127de0-db1a-4597-a1f2-c35b6c389348",
+                            "id": "3322b51e-5354-43c3-8d48-3e522f873875",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3698,7 +4478,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3720,7 +4500,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 443.11519282652864\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3746,7 +4526,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3763,7 +4543,7 @@
             "description": "Operational log entries.",
             "item": [
                 {
-                    "id": "777086b2-79ba-4c51-86c4-961be581631c",
+                    "id": "41a1cb13-c97d-4b91-9cbb-6a98547b97bb",
                     "name": "Upload operational logs (batch)",
                     "request": {
                         "name": "Upload operational logs (batch)",
@@ -3790,7 +4570,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -3804,7 +4584,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -3816,7 +4596,7 @@
                     },
                     "response": [
                         {
-                            "id": "962f2d66-c025-46e5-b77c-fb7e485b6e19",
+                            "id": "e5961036-e886-4000-8a73-6c4f40272b6a",
                             "name": "Logs processed",
                             "originalRequest": {
                                 "url": {
@@ -3838,7 +4618,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3860,7 +4640,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3886,12 +4666,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": false,\n  \"key_1\": 9938,\n  \"key_2\": 2370.641984077114\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "75a93609-4450-4610-84f3-fb222a22b2bc",
+                            "id": "dee3bfb3-2e0f-4717-8b94-9a444626a012",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3913,7 +4693,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3935,7 +4715,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3961,12 +4741,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b8730a32-1d0f-4a6c-975e-4048933bbc30",
+                            "id": "4c50c405-eb45-4533-90b2-0b500dfce99f",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3988,7 +4768,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4010,7 +4790,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4036,12 +4816,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ccb12286-6861-4f76-a0b2-31b4fd102939",
+                            "id": "467787cc-6304-4e64-9864-5cdbb181730c",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4063,7 +4843,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4085,7 +4865,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4111,12 +4891,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1df2637b-4115-49b6-8f81-ad480c1c6ddf",
+                            "id": "a844ab98-c00d-4d9c-bff4-7f45bb18bbbe",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -4138,7 +4918,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4160,7 +4940,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4186,7 +4966,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4203,7 +4983,7 @@
             "description": "Read records and logs.",
             "item": [
                 {
-                    "id": "20c59a3d-82cf-4c71-bd08-207de856ccbf",
+                    "id": "fd74a8cd-d2bd-435b-8bfc-1569f9691dc7",
                     "name": "Query conversation records",
                     "request": {
                         "name": "Query conversation records",
@@ -4226,7 +5006,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -4252,7 +5032,7 @@
                     },
                     "response": [
                         {
-                            "id": "235a86df-ee5a-4157-b6e3-87ffc15593ca",
+                            "id": "518fdeeb-1922-42b9-956a-40ab6ad12131",
                             "name": "Records matching the query",
                             "originalRequest": {
                                 "url": {
@@ -4273,7 +5053,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4321,12 +5101,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"user\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": \"string\",\n            \"key_2\": true\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 1246\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 8776.463025717552\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"user\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 6983.5879070411165,\n            \"key_1\": 9495.87641521313\n          },\n          {\n            \"key_0\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"user\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3492\n          },\n          {\n            \"key_0\": 7629,\n            \"key_1\": 6065,\n            \"key_2\": 4036.815064908904\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"teams\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "24c08caf-9af6-4229-9f79-b5050a3d74b2",
+                            "id": "aba5c676-9b3b-463e-a7ec-cdd37be5f6ea",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4347,7 +5127,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4395,12 +5175,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7be6cd02-a92b-4214-a7a3-8e06aefb9902",
+                            "id": "df819a83-0c07-412d-9b64-52145e328af1",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4421,7 +5201,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4469,12 +5249,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f2b5ce81-5ec7-42ca-a109-684d4ae4dbe0",
+                            "id": "7ade7c88-312e-4d7f-be33-4b1cdc3e5f92",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4495,7 +5275,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4543,12 +5323,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "02fd1822-4568-4dfc-af49-90e12ce5822e",
+                            "id": "adff4da3-bcdb-4c82-a122-9069d2350284",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -4569,7 +5349,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4617,7 +5397,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4628,7 +5408,7 @@
                     }
                 },
                 {
-                    "id": "17f06463-6fde-4166-8fd2-efd277d5500f",
+                    "id": "b21392a1-c956-4b81-8d5a-d787e47e6063",
                     "name": "Query log entries",
                     "request": {
                         "name": "Query log entries",
@@ -4652,7 +5432,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -4666,7 +5446,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -4678,7 +5458,7 @@
                     },
                     "response": [
                         {
-                            "id": "d6808a37-67ff-4d91-b2ca-5f91a9a1ab60",
+                            "id": "72b50461-7067-4060-8e97-4ba50c112d70",
                             "name": "Logs matching the query",
                             "originalRequest": {
                                 "url": {
@@ -4700,7 +5480,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4722,7 +5502,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4748,12 +5528,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 3758.1973690649693,\n        \"key_1\": \"string\"\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 5362,\n        \"key_1\": true,\n        \"key_2\": true\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 3250.963957547204,\n        \"key_1\": 7147\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "80782fa1-8b24-48ff-a664-5a85dc7f5bf0",
+                            "id": "2363890b-be35-4a2e-ad98-4a49a3ccb5ae",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4775,7 +5555,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4797,7 +5577,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4823,12 +5603,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "42056d0c-d99a-40a6-8dd3-7bd2e122126f",
+                            "id": "0b6ac627-82a7-4476-8b3c-7fe2528c26a4",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4850,7 +5630,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4872,7 +5652,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4898,12 +5678,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "eeee3614-98a7-4a75-8706-1c895bf4e55f",
+                            "id": "fcbd8eb5-8c53-4dce-83b4-e46c45c0afb5",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4925,7 +5705,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4947,7 +5727,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4973,12 +5753,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f642b82a-1148-4da1-a43c-4e7381234e30",
+                            "id": "5a785b8c-9283-45c3-b6eb-50b1351a2416",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5000,7 +5780,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5022,7 +5802,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5048,7 +5828,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5065,7 +5845,7 @@
             "description": "Bulk export with server-side pagination.",
             "item": [
                 {
-                    "id": "6cd23e3d-8e1f-4bf0-8357-d68d7d545bae",
+                    "id": "4b8cc088-31de-4db0-b881-e4a7f0d44e5a",
                     "name": "Export conversation records (JSON or CSV)",
                     "request": {
                         "name": "Export conversation records (JSON or CSV)",
@@ -5089,7 +5869,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -5115,7 +5895,7 @@
                     },
                     "response": [
                         {
-                            "id": "1e585de0-db97-4975-abc1-2ea6eb94ea61",
+                            "id": "d3d026e8-e0ed-4e85-b126-4220187c253a",
                             "name": "Records exported",
                             "originalRequest": {
                                 "url": {
@@ -5137,7 +5917,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5185,12 +5965,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 6397\n          },\n          {\n            \"key_0\": 584\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 7286,\n            \"key_1\": false\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9469.721268734858\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true,\n            \"key_2\": 2849,\n            \"key_3\": 9204\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 881.0815020854012\n          },\n          {\n            \"key_0\": 5167,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"teams\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "acd40db4-c223-4256-81df-f4062170344c",
+                            "id": "61340330-2816-4228-9265-66dc57b6a314",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5212,7 +5992,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5260,12 +6040,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a588e833-b273-4a46-b252-e3b63db3a9c8",
+                            "id": "d2920e58-4cce-4864-872e-1c0fbdbff440",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5287,7 +6067,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5335,12 +6115,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "79829992-9794-4b20-b352-335d34c22f21",
+                            "id": "1d361907-b308-49e4-9455-15ac2b5cd971",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -5362,7 +6142,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5410,12 +6190,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4b857743-8089-42b8-92ac-897785ce454a",
+                            "id": "af4bfe46-8a21-4f08-aa0f-a65d16b12320",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5437,7 +6217,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5485,7 +6265,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5496,7 +6276,7 @@
                     }
                 },
                 {
-                    "id": "0afa6373-d454-4a63-ab52-74283f6aa2ee",
+                    "id": "5272e9af-32ba-4cc4-8e62-02561cd8fcef",
                     "name": "Export logs (JSON or CSV)",
                     "request": {
                         "name": "Export logs (JSON or CSV)",
@@ -5520,7 +6300,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                "value": "8fyH3t[\"EOGhh"
                             },
                             {
                                 "key": "Content-Type",
@@ -5534,7 +6314,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -5546,7 +6326,7 @@
                     },
                     "response": [
                         {
-                            "id": "0994a0b3-7bbc-4994-aef6-52139f607263",
+                            "id": "0b7c420e-b331-4003-8238-056bfee5c18b",
                             "name": "Logs exported",
                             "originalRequest": {
                                 "url": {
@@ -5568,7 +6348,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5590,7 +6370,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5616,12 +6396,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 7386.8936277919165\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 6461.955984018873,\n        \"key_1\": true\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": 5905.068480794311\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 5083.693839192576,\n        \"key_1\": 5020.4676053592275\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5b6662ae-cd57-4402-b8b8-1383a7bd2113",
+                            "id": "04cd7014-ae34-44ba-b9fb-25a807d149a9",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5643,7 +6423,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5665,7 +6445,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5691,12 +6471,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d311da1b-95ea-4436-98a3-0d48b65cdf9c",
+                            "id": "71c572eb-c774-466e-9e2d-cad6cc9d261d",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5718,7 +6498,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5740,7 +6520,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5766,12 +6546,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cb06a20e-afc7-44b0-a2b5-065d5255637b",
+                            "id": "9de234c1-4ae4-4917-9f21-f316342aa288",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -5793,7 +6573,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5815,7 +6595,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5841,12 +6621,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "49951922-a797-49ad-9393-4047c7fa69ec",
+                            "id": "418c6bb8-153f-43a7-b727-a92f64c17031",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5868,7 +6648,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "PnCx%mcz9MfE]39}GKZAlsG3I#iqSj(^PzRO){?8MbC.PvEr\"+%RSOF4{T9Zkn48;-?0TmwU\\Ixzt suy[n] <<RtP&m)DMY8CHGObF2%cppp>rE)R>AsNmY~d\\}s"
+                                        "value": "8fyH3t[\"EOGhh"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5890,7 +6670,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5916,7 +6696,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"internal_error\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5947,7 +6727,7 @@
         }
     ],
     "info": {
-        "_postman_id": "58ce2715-582f-456c-9b64-b9c71c984534",
+        "_postman_id": "73b9790c-d32e-416a-972a-527475be179e",
         "name": "MonkAI Trace API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
## O que foi feito

Companion docs do que ja esta deployado em prod (monkai-api v143):
- [BeMonkAI/monkai-agent-hub#25](https://github.com/BeMonkAI/monkai-agent-hub/pull/25) — edge function + migration

### \`docs/openapi.yaml\`
- **Novo parameter** \`IdempotencyKeyHeader\` (1-128 ASCII, mesma charset do X-Request-ID) wired nos 5 trace endpoints
- **Novos headers** \`IdempotencyReplay\` (literal \"true\") + \`IdempotencyOriginalRequestId\` nas responses 200/201
- **Nova response component** \`Conflict\` (422) com envelope estruturado, wired nos 5 endpoints
- **Novo error code** \`idempotency_key_conflict\` no enum canonico

### \`docs/http_rest_api.md\`
- Nova secao **\"Idempotency — \`Idempotency-Key\`\"** antes de User Identification
- Tabela de comportamento (same key+body / same key+diff body / different key)
- Pattern recomendado (Node.js)
- Format constraints

### \`docs/MIGRATION.md\`
- Nova secao **\"5. Safe retries with \`Idempotency-Key\`\"** com adocao opt-in, leitura de replay headers, remediacao de conflito, tabela de suporte por endpoint
- Summary table atualizada com 5a mudanca

### \`docs/API_CHANGELOG.md\`
- Nova entry \`[v1.3] — 2026-05-02\` documentando a feature
- \"Planned (Phase 3)\" agora so tem 1 item: rate-limit headers

### \`docs/postman_collection.json\`
- Regenerado (7 folders / 15 requests)

## Como testar

\`\`\`bash
.venv/bin/python -c \"from openapi_spec_validator import validate; import yaml; validate(yaml.safe_load(open('docs/openapi.yaml')))\"
npx --yes @redocly/cli@latest lint docs/openapi.yaml --config docs/redocly.yaml

# Smoke contra prod (versao 143):
TOKEN=tk_xxx
KEY=trace-doc-smoke
BODY='{\"session_id\":\"sess_x\",\"level\":\"info\",\"message\":\"hi\"}'

curl -i -X POST -H \"Authorization: Bearer \$TOKEN\" -H \"Idempotency-Key: \$KEY\" \\
  -H \"Content-Type: application/json\" -d \"\$BODY\" \\
  https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/log
# Esperado 1a chamada: 201 sem header de replay

curl -i -X POST -H \"Authorization: Bearer \$TOKEN\" -H \"Idempotency-Key: \$KEY\" \\
  -H \"Content-Type: application/json\" -d \"\$BODY\" \\
  https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/traces/log
# Esperado 2a chamada: 201 + Idempotency-Replay: true + Idempotency-Original-Request-ID
\`\`\`

## Checklist

- [x] OpenAPI 3.1 valido (14 paths, 41 schemas)
- [x] Redocly lint zero warnings
- [x] Postman regenerado (7/15)
- [x] Mudanca 100% docs (zero codigo runtime)
- [x] Reflete prod (monkai-api v143)
- [x] Companion das mudancas em monkai-hub#25

## Apos merge

Site Pages rebuilda automatico (~1 min). \`bemonkai.github.io/monkai-trace/\` vai mostrar Idempotency-Key na lista de parameters/responses dos endpoints afetados.

## Proximo (ultima peca da Fase 3)

Rate-limit response headers (\`X-RateLimit-Limit\`, \`-Remaining\`, \`-Reset\`) — precisa decisao de politica de limites antes de implementar.

Refs #12