### PR TITLE
docs(api): rate limiting (companion to monkai-hub#26) — Fase 3 closes

### DIFF
--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -12,11 +12,37 @@ keep working during a deprecation window.
 
 ## [Unreleased]
 
-### Planned (Phase 3 — remaining)
-- Rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
-
 ### Planned (Phase 2 — remaining)
 - Custom domain `https://api.monkai.ai/trace/v1`.
+
+## [v1.4] — 2026-05-02
+
+### Added
+- **Per-token rate limiting** with response headers on every
+  request to a rate-limited endpoint. Both legacy `X-RateLimit-*`
+  and IETF draft `RateLimit-*` names are emitted.
+- New canonical error code **`rate_limit_exceeded`** (HTTP 429).
+  The 429 response also carries `Retry-After: <seconds>` per
+  RFC 6585. The `error.message` includes the bucket name so
+  clients/support can identify which limit was hit.
+- Buckets and limits (per token, per minute, fixed window):
+  `traces=600`, `traces_batch=60`, `bulk_upload=60`,
+  `sessions=600`, `query=60`, `rules=60`. `GET /v1/health` is
+  intentionally unlimited.
+- References: [BeMonkAI/monkai-agent-hub#26](https://github.com/BeMonkAI/monkai-agent-hub/pull/26)
+  (edge function + migration + RPC) and
+  [`docs/MIGRATION.md`](./MIGRATION.md#6-handle-rate-limits)
+  (client adoption guide).
+
+### Notes
+- Counters live in the `monkai_rate_limits` Postgres table with
+  per-`(token_id, bucket, minute)` PK. Increment is atomic via the
+  `monkai_increment_rate_limit` RPC (SECURITY DEFINER, locked down
+  to `service_role`).
+- Cache failures fail open — a flaky DB never takes down the API,
+  it just stops enforcing limits temporarily (logged server-side).
+- **Phase 3 of the API roadmap is complete with this release.**
+  Only `Phase 2 — custom domain` remains as a roadmap item.
 
 ## [v1.3] — 2026-05-02
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -336,6 +336,48 @@ fix the body so it matches the original):
 
 ---
 
+## 6. Handle rate limits
+
+Phase 3 final piece: every authenticated endpoint (except
+`/v1/health`) is rate-limited per `tracer_token`. Most clients
+won't notice — limits are deliberately generous (600 traces/min,
+60 batches/min, 60 bulk uploads/min). Production code should still
+handle the `429` gracefully.
+
+### What changed
+
+- Every response from a rate-limited endpoint now carries
+  `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+  (and the IETF draft `RateLimit-*` equivalents).
+- When the quota is exhausted, the server returns
+  `429 rate_limit_exceeded` with `Retry-After` header.
+
+### Recommended pattern
+
+```javascript
+async function callWithBackoff(fetchOnce) {
+  let res = await fetchOnce();
+  if (res.status === 429) {
+    const wait = parseInt(res.headers.get("Retry-After") ?? "1", 10);
+    await new Promise(r => setTimeout(r, wait * 1000));
+    res = await fetchOnce();  // single retry; surface failure if 429 again
+  }
+  return res;
+}
+```
+
+For long-running batch jobs, **read `X-RateLimit-Remaining` after
+every call** and self-pace when it gets close to 0 — preferable
+to hitting 429 and waiting for `Retry-After`.
+
+### Diagnosing rate-limit issues
+
+Quote `request_id` from the 429 body or the `X-Request-ID` response
+header in support tickets. With the bucket name in `error.message`
+support can confirm exactly which bucket you're hitting.
+
+---
+
 ## Summary table
 
 | Change | Action | Required by |
@@ -345,6 +387,7 @@ fix the body so it matches the original):
 | `X-Request-ID` | Generate per call, log on errors | Optional, recommended for prod |
 | Error shape | Read `error.message` and `error.code` | Required if you rendered `error` as a string |
 | `Idempotency-Key` | Generate per logical operation, reuse across retries | Optional, recommended for prod |
+| Rate limits | Read `X-RateLimit-Remaining`, handle `429 + Retry-After` | Required if you hit the limits (most don't) |
 
 ---
 

--- a/docs/http_rest_api.md
+++ b/docs/http_rest_api.md
@@ -57,6 +57,80 @@ curl -i -H "Authorization: Bearer tk_YOUR_TOKEN" \
 #   x-request-id: my-trace-1
 ```
 
+## Rate Limiting
+
+Every authenticated request to a rate-limited endpoint returns
+quota headers, regardless of status. When the per-token quota is
+exhausted the server returns `429 rate_limit_exceeded` with a
+`Retry-After` hint.
+
+### Limits (per `tracer_token`, per minute, fixed window)
+
+| Bucket | Limit | Endpoints |
+|---|---:|---|
+| `traces` | 600 | `POST /v1/traces/llm`, `/tool`, `/handoff`, `/log` |
+| `traces_batch` | 60 | `POST /v1/traces/batch` (each batch holds up to 100 items) |
+| `bulk_upload` | 60 | `POST /v1/records/upload`, `/v1/logs/upload` |
+| `sessions` | 600 | `POST /v1/sessions/create`, `/v1/sessions/get-or-create` |
+| `query` | 60 | `POST /v1/record_query`, `/v1/logs/query`, `/v1/records/export`, `/v1/logs/export` |
+| `rules` | 60 | `GET` and `PUT /v1/anonymization-rules` |
+
+`GET /v1/health` is intentionally **unlimited** — monitors and
+load balancers can ping it as often as they need.
+
+### Headers
+
+Every response from a rate-limited endpoint carries:
+
+```
+X-RateLimit-Limit: 600
+X-RateLimit-Remaining: 599
+X-RateLimit-Reset: 47        ← seconds until window resets
+RateLimit-Limit: 600
+RateLimit-Remaining: 599
+RateLimit-Reset: 47
+```
+
+Both legacy `X-RateLimit-*` and the modern IETF draft `RateLimit-*`
+names are emitted so old and new HTTP clients both see them.
+
+### `429 rate_limit_exceeded`
+
+```http
+HTTP/2 429 Too Many Requests
+X-RateLimit-Limit: 600
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 12
+Retry-After: 12
+Content-Type: application/json
+
+{
+  "error": {
+    "code": "rate_limit_exceeded",
+    "message": "Rate limit exceeded for bucket \"traces\". Limit 600/min — retry in 12s.",
+    "request_id": "8c5d96f1-..."
+  }
+}
+```
+
+### Recommended client pattern
+
+Wait `Retry-After` (or `RateLimit-Reset`) seconds before retrying.
+Both headers carry the same value on a 429.
+
+```javascript
+async function postWithRateLimit(url, body, opts = {}) {
+  const res = await fetch(url, opts);
+  if (res.status !== 429) return res;
+  const wait = parseInt(res.headers.get("Retry-After") ?? "1", 10);
+  await new Promise(r => setTimeout(r, wait * 1000));
+  return postWithRateLimit(url, body, opts);  // retry once
+}
+```
+
+For long-running batch jobs, watch `X-RateLimit-Remaining` to
+self-pace before hitting 429.
+
 ## Idempotency — `Idempotency-Key`
 
 Trace endpoints (`/v1/traces/llm`, `/tool`, `/handoff`, `/log`,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -150,6 +150,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -163,6 +169,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -219,6 +227,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -235,6 +249,8 @@ paths:
   # ============================================================
   # TRACES (language-agnostic surface)
   # ============================================================
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -292,6 +308,12 @@ paths:
               $ref: '#/components/headers/IdempotencyReplay'
             Idempotency-Original-Request-ID:
               $ref: '#/components/headers/IdempotencyOriginalRequestId'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -307,6 +329,8 @@ paths:
 
         '422':
           $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -363,6 +387,12 @@ paths:
               $ref: '#/components/headers/IdempotencyReplay'
             Idempotency-Original-Request-ID:
               $ref: '#/components/headers/IdempotencyOriginalRequestId'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -378,6 +408,8 @@ paths:
 
         '422':
           $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -434,6 +466,12 @@ paths:
               $ref: '#/components/headers/IdempotencyReplay'
             Idempotency-Original-Request-ID:
               $ref: '#/components/headers/IdempotencyOriginalRequestId'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -449,6 +487,8 @@ paths:
 
         '422':
           $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -507,6 +547,12 @@ paths:
               $ref: '#/components/headers/IdempotencyReplay'
             Idempotency-Original-Request-ID:
               $ref: '#/components/headers/IdempotencyOriginalRequestId'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -525,6 +571,8 @@ paths:
   # ============================================================
         '422':
           $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -598,6 +646,12 @@ paths:
               $ref: '#/components/headers/IdempotencyReplay'
             Idempotency-Original-Request-ID:
               $ref: '#/components/headers/IdempotencyOriginalRequestId'
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -613,6 +667,8 @@ paths:
 
         '422':
           $ref: '#/components/responses/Conflict'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -669,6 +725,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -682,6 +744,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -734,6 +798,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -750,6 +820,8 @@ paths:
   # ============================================================
   # QUERY
   # ============================================================
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -801,6 +873,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -814,6 +892,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -865,6 +945,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -881,6 +967,8 @@ paths:
   # ============================================================
   # EXPORT
   # ============================================================
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -932,6 +1020,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -949,6 +1043,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -1000,6 +1096,12 @@ paths:
           headers:
             X-Request-ID:
               $ref: "#/components/headers/XRequestId"
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -1017,6 +1119,8 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
       x-codeSamples:
         - lang: Shell
           label: curl
@@ -1141,6 +1245,46 @@ components:
         request whose result is being returned. Use it to find the
         first request in server logs.
 
+    RateLimitLimit:
+      schema:
+        type: integer
+        minimum: 0
+      description: |
+        Per-token request limit for the current bucket, in
+        requests/minute. Bucket is determined by the route — see the
+        narrative docs for the table. Emitted on every response from
+        a rate-limited endpoint (200, 4xx, 5xx). The response also
+        carries the modern `RateLimit-Limit` header (IETF draft) with
+        the same value.
+
+    RateLimitRemaining:
+      schema:
+        type: integer
+        minimum: 0
+      description: |
+        Requests still available in the current 1-minute window.
+        Reaches `0` on the request that exhausts the quota; the
+        next call returns `429`. Also emitted as `RateLimit-Remaining`.
+
+    RateLimitReset:
+      schema:
+        type: integer
+        minimum: 0
+        maximum: 60
+      description: |
+        Seconds until the current 1-minute window resets and the
+        full quota is restored. Always between 0 and 60. Also
+        emitted as `RateLimit-Reset`.
+
+    RetryAfter:
+      schema:
+        type: integer
+        minimum: 0
+      description: |
+        Seconds the client should wait before retrying. Emitted with
+        `429 rate_limit_exceeded` (RFC 6585). Identical to
+        `RateLimit-Reset` on `429` responses.
+
   responses:
     BadRequest:
       description: Bad Request — required field missing or invalid payload
@@ -1177,6 +1321,28 @@ components:
       headers:
         X-Request-ID:
           $ref: "#/components/headers/XRequestId"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    TooManyRequests:
+      description: |
+        Per-token rate limit exceeded for the bucket the route belongs
+        to. The error envelope carries `code: "rate_limit_exceeded"`.
+        Wait `Retry-After` seconds (or `RateLimit-Reset` — they're
+        identical here) and retry. Limits are per-token, per-minute,
+        fixed window.
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestId"
+        X-RateLimit-Limit:
+          $ref: "#/components/headers/RateLimitLimit"
+        X-RateLimit-Remaining:
+          $ref: "#/components/headers/RateLimitRemaining"
+        X-RateLimit-Reset:
+          $ref: "#/components/headers/RateLimitReset"
+        Retry-After:
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -1388,6 +1554,7 @@ components:
                 - encryption_error
                 - anonymization_error
                 - idempotency_key_conflict
+                - rate_limit_exceeded
               example: missing_token
             message:
               type: string

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -5,7 +5,7 @@
             "description": "Liveness check (no auth required).",
             "item": [
                 {
-                    "id": "54a13ce2-95ae-4e9b-8826-5593aa704b58",
+                    "id": "9093472e-6611-4589-868f-9a045bcc6c48",
                     "name": "Liveness check",
                     "request": {
                         "name": "Liveness check",
@@ -35,7 +35,7 @@
                     },
                     "response": [
                         {
-                            "id": "0c84c76f-4fae-430d-ab76-30b96d90d1e4",
+                            "id": "86b70d9f-9170-4ed5-a81a-9596ca9641c2",
                             "name": "Service is responsive",
                             "originalRequest": {
                                 "url": {
@@ -87,7 +87,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b03ba9fb-c1de-4d91-be5e-889ac43065e7",
+                            "id": "9ea6faa5-2c7d-4e53-bd66-8ef8bf73b86c",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -134,7 +134,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -145,7 +145,7 @@
                     }
                 },
                 {
-                    "id": "cd177283-a115-47b3-abb9-4c5f5e474e34",
+                    "id": "0e02b9d9-af70-4119-9b0f-3fe2f9fef4ad",
                     "name": "Liveness check (HEAD variant)",
                     "request": {
                         "name": "Liveness check (HEAD variant)",
@@ -175,7 +175,7 @@
                     },
                     "response": [
                         {
-                            "id": "ecaac1c5-49e2-4f5e-8f1d-c2151dfe847c",
+                            "id": "244c5384-0466-4a2a-b303-2a918c0c8672",
                             "name": "Service is responsive (no body)",
                             "originalRequest": {
                                 "url": {
@@ -218,7 +218,7 @@
                             "_postman_previewlanguage": "text"
                         },
                         {
-                            "id": "8bfa6ded-3a8f-4034-8aa2-0c081d8b3e64",
+                            "id": "4b66618d-3fac-41cb-a04a-36f86c06f008",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -265,7 +265,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -282,7 +282,7 @@
             "description": "Manage conversation sessions.",
             "item": [
                 {
-                    "id": "8c095856-b36b-4c28-be64-82df2abee3ee",
+                    "id": "2ea16650-0f96-443e-9688-0f6b60a8acc4",
                     "name": "Create a new session",
                     "request": {
                         "name": "Create a new session",
@@ -309,7 +309,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -323,7 +323,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -335,7 +335,7 @@
                     },
                     "response": [
                         {
-                            "id": "0e039b39-50e6-4591-9dcd-b3e505812c58",
+                            "id": "9784a3c0-5696-4854-aa04-de5d5d57e0ee",
                             "name": "Session created",
                             "originalRequest": {
                                 "url": {
@@ -357,7 +357,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -379,7 +379,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -403,14 +403,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3e0ba237-44d2-4cc9-bece-0f4d122fce63",
+                            "id": "501a202f-c78a-4eb8-9a59-422de7d2e2d8",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -432,7 +459,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -454,7 +481,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -480,12 +507,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bb2ee349-f96d-4c08-bd5c-68ffb8bec337",
+                            "id": "2cf53dec-2dc0-446e-83b1-506e23df37be",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -507,7 +534,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -529,7 +556,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -555,12 +582,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c6a8251c-e261-4fba-9ce0-6793650a062d",
+                            "id": "8c85ab81-b83a-45f7-905c-1d16b048290e",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -582,7 +609,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -604,7 +631,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -630,13 +657,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "63740a93-f9a8-449a-8ee4-e4f31701c0b0",
-                            "name": "Internal Server Error",
+                            "id": "3f29e7c3-8bc0-4bc4-b201-86964cdfedc9",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -657,7 +684,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -679,7 +706,118 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 2003.6484119281706\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "27e971c5-852a-4ae4-95d6-3e5d9173da31",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -705,7 +843,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -716,7 +854,7 @@
                     }
                 },
                 {
-                    "id": "4f5bd6a4-b201-49d6-a490-9707834c2382",
+                    "id": "4fee1218-1e93-4ec2-a688-cfcbe5467f49",
                     "name": "Get an active session or create a new one",
                     "request": {
                         "name": "Get an active session or create a new one",
@@ -743,7 +881,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -769,7 +907,7 @@
                     },
                     "response": [
                         {
-                            "id": "a2a1822d-055f-4b32-b369-e39bff6ff9d9",
+                            "id": "f57bc174-b248-49ae-91bc-14aa9075e401",
                             "name": "Session returned (existing or new)",
                             "originalRequest": {
                                 "url": {
@@ -791,7 +929,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -837,14 +975,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"reused\": \"<boolean>\"\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2983.6652259357575\n  },\n  \"reused\": \"<boolean>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cf914e2d-3ccb-4cd3-bdde-462affe5dbd5",
+                            "id": "9b6dd6bd-87fb-4125-8518-e0c4d52fc416",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -866,7 +1031,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -914,12 +1079,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2944e687-c514-4ac9-b962-453be5c66002",
+                            "id": "0c238756-362a-4d76-8f97-7cb50472720a",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -941,7 +1106,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -989,12 +1154,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4222508d-1e86-4472-bd31-f2ba0bd0faa2",
+                            "id": "5e3e2e9d-e5cf-471e-a5d6-9c7e8b5d24ca",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1016,7 +1181,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1064,12 +1229,123 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3615ad03-64ac-43db-8b82-f8541aae209f",
+                            "id": "fd8bb8bd-5590-4e33-b2bd-4b636282ea4d",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "sessions",
+                                        "get-or-create"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"force_new\": false\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "865c0f34-fdae-423e-9316-eb354a7c250a",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -1091,7 +1367,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1139,7 +1415,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1156,7 +1432,7 @@
             "description": "Record fine-grained events. Preferred for HTTP clients in any language.",
             "item": [
                 {
-                    "id": "aedb2203-2657-467c-9537-e553285191c1",
+                    "id": "73999b24-2c2b-42a4-b8d3-0aeb817fec92",
                     "name": "Trace an LLM call",
                     "request": {
                         "name": "Trace an LLM call",
@@ -1180,7 +1456,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "disabled": false,
@@ -1189,7 +1465,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -1203,7 +1479,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1215,7 +1491,7 @@
                     },
                     "response": [
                         {
-                            "id": "e8820590-aa12-4555-be6e-9d0474f6907f",
+                            "id": "00578c00-f931-40ae-bcb9-1a5746239b36",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1237,7 +1513,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1246,7 +1522,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1268,7 +1544,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1310,6 +1586,33 @@
                                     },
                                     "key": "Idempotency-Original-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"tokens\": {\n    \"input\": \"<integer>\",\n    \"output\": \"<integer>\"\n  }\n}",
@@ -1317,7 +1620,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "67b7e23e-857c-4af3-bf3b-12845593b647",
+                            "id": "49966501-c16a-4d1f-9145-5e5802231e66",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1339,7 +1642,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1348,7 +1651,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1370,7 +1673,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1396,12 +1699,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3b9ccc5d-7501-4a59-8353-ec68d9bd1f83",
+                            "id": "7aacd671-8f72-41b1-8b96-944891fcca69",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1423,7 +1726,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1432,7 +1735,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1454,7 +1757,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1480,12 +1783,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "970be5e0-ea3a-4942-ba89-4cf3c68ae581",
+                            "id": "11de4ab6-e352-4b16-a675-e3a9a9cac4d2",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1507,7 +1810,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1516,7 +1819,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1538,7 +1841,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1564,12 +1867,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "765cb301-53bd-4989-9900-aac5de44c6ea",
+                            "id": "200cd9f0-8294-426b-a257-0053f724d11e",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -1591,7 +1894,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1600,7 +1903,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1622,7 +1925,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1648,13 +1951,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0f01164f-a0e8-42b5-8a43-5aa81c39bcba",
-                            "name": "Internal Server Error",
+                            "id": "5dc4abed-b5fb-43c7-a937-8bc07cfe543b",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -1675,7 +1978,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1684,7 +1987,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1706,7 +2009,127 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 369.24652525734734,\n    \"key_1\": 3422\n  },\n  \"output\": {\n    \"key_0\": 7525,\n    \"key_1\": true\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6252,\n    \"key_1\": 6599.433815730531\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6f1faca5-7e69-48f0-85c5-2422d435acd7",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "llm"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1732,7 +2155,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1743,7 +2166,7 @@
                     }
                 },
                 {
-                    "id": "c394ae39-7fff-4bd6-81af-752649989e38",
+                    "id": "6ee3c98b-0682-423a-9bed-7bc7e2dfb0b3",
                     "name": "Trace a tool/function call",
                     "request": {
                         "name": "Trace a tool/function call",
@@ -1767,7 +2190,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "disabled": false,
@@ -1776,7 +2199,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -1790,7 +2213,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1802,7 +2225,7 @@
                     },
                     "response": [
                         {
-                            "id": "3de35413-8090-4e0c-ad25-c1519c291e85",
+                            "id": "c5f06490-ecd7-4267-ae3a-6219386146c3",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1824,7 +2247,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1833,7 +2256,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1855,7 +2278,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1897,6 +2320,33 @@
                                     },
                                     "key": "Idempotency-Original-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"tool_name\": \"<string>\"\n}",
@@ -1904,7 +2354,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "77ba1104-80a9-42f2-9287-64ae2220dd7d",
+                            "id": "b48d564c-a374-43f0-aabb-7fb0dc585b2e",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1926,7 +2376,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -1935,7 +2385,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1957,7 +2407,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1983,12 +2433,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d56ab5ef-d83d-483b-84dc-49bb40068810",
+                            "id": "8be06318-b4d2-42a0-8249-f672639e4fc6",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2010,7 +2460,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2019,7 +2469,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2041,7 +2491,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2067,12 +2517,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a3a4d098-f9c9-42f2-be50-7f209bb884fc",
+                            "id": "42ac8d6d-c5c5-463a-a2c4-654512c450d4",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2094,7 +2544,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2103,7 +2553,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2125,7 +2575,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2151,12 +2601,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "81e79372-7a68-4b0a-8e62-deac6eb8505b",
+                            "id": "77eb1a5a-9c13-4984-b3fa-dfe675853d21",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -2178,7 +2628,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2187,7 +2637,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2209,7 +2659,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2235,13 +2685,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "092c4a11-3985-46a6-bd38-318b4828e6c0",
-                            "name": "Internal Server Error",
+                            "id": "432491b9-aae3-42fa-b6a0-de6a2d76684e",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -2262,7 +2712,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2271,7 +2721,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2293,7 +2743,127 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 1962,\n    \"key_1\": 5722\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 3206,\n    \"key_1\": 8567.405710451712,\n    \"key_2\": 4097.869833049848\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"teams\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2227fea9-7026-4c6d-b0cf-397d7c06884e",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "tool"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2319,7 +2889,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2330,7 +2900,7 @@
                     }
                 },
                 {
-                    "id": "8e9746ea-3358-4d01-b04c-b478ffc0cd63",
+                    "id": "228947da-162f-4dcb-ac43-ca6f446dcdae",
                     "name": "Trace an agent-to-agent handoff",
                     "request": {
                         "name": "Trace an agent-to-agent handoff",
@@ -2354,7 +2924,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "disabled": false,
@@ -2363,7 +2933,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -2377,7 +2947,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2389,7 +2959,7 @@
                     },
                     "response": [
                         {
-                            "id": "a48301ef-34fd-4142-a317-fc322dc1d260",
+                            "id": "33fb38da-2959-4abb-a30f-9fed63a9cb80",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -2411,7 +2981,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2420,7 +2990,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2442,7 +3012,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2484,6 +3054,33 @@
                                     },
                                     "key": "Idempotency-Original-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\",\n  \"from\": \"<string>\",\n  \"to\": \"<string>\"\n}",
@@ -2491,7 +3088,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "469c58cc-7462-4b84-855b-aeba21e7cfb9",
+                            "id": "700f65e0-5203-4feb-82f6-5772ff0291ae",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -2513,7 +3110,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2522,7 +3119,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2544,7 +3141,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2570,12 +3167,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fe523586-dd90-4d0d-a29c-bdb0cf97d1dd",
+                            "id": "99b2a9cf-8f8b-4a36-9c18-2200ddc99e4e",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2597,7 +3194,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2606,7 +3203,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2628,7 +3225,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2654,12 +3251,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4789a016-b157-46fd-927d-ecc7273b9235",
+                            "id": "64ac2530-7c87-49a9-a025-fd36491207e6",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2681,7 +3278,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2690,7 +3287,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2712,7 +3309,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2738,12 +3335,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1951db7d-1f9c-42f4-b273-b8c573bdbcfd",
+                            "id": "52ad466a-167f-4c5a-a9d9-983b42a1a1d3",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -2765,7 +3362,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2774,7 +3371,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2796,7 +3393,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2822,13 +3419,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6b4f6b57-8edb-4d77-b337-fa7e3c060556",
-                            "name": "Internal Server Error",
+                            "id": "36716339-9994-44f1-bb10-1e8eff21c967",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -2849,7 +3446,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -2858,7 +3455,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2880,7 +3477,127 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true,\n    \"key_1\": 4623\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"sms\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "087723bd-90e5-459a-aea6-3b939d87c598",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "handoff"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2906,7 +3623,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2917,7 +3634,7 @@
                     }
                 },
                 {
-                    "id": "abc8b491-3208-4b66-9a02-e41e3b7b1c6b",
+                    "id": "5247b69a-99ed-4d37-ba5e-ded4174b8c26",
                     "name": "Trace a log entry",
                     "request": {
                         "name": "Trace a log entry",
@@ -2944,7 +3661,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "disabled": false,
@@ -2953,7 +3670,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -2967,7 +3684,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2979,7 +3696,7 @@
                     },
                     "response": [
                         {
-                            "id": "1c68aeeb-1fd7-4065-9cfc-91163649d197",
+                            "id": "0d8cc4b8-28fa-4e73-b3b5-af7dd9799990",
                             "name": "Log recorded",
                             "originalRequest": {
                                 "url": {
@@ -3001,7 +3718,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3010,7 +3727,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3032,7 +3749,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3074,6 +3791,33 @@
                                     },
                                     "key": "Idempotency-Original-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
                             "body": "{\n  \"success\": \"<boolean>\",\n  \"trace_type\": \"<string>\"\n}",
@@ -3081,7 +3825,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "55852152-598e-42ee-af73-4136a3d27c74",
+                            "id": "d7ee93c2-84c0-473d-8fe3-387fa9671e7d",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3103,7 +3847,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3112,7 +3856,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3134,7 +3878,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3160,12 +3904,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cbae8323-a681-4568-bed4-06b1921262aa",
+                            "id": "85a1a0f7-6335-4a78-8041-7a67b38a2f5a",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3187,7 +3931,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3196,7 +3940,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3218,7 +3962,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3244,12 +3988,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7ebbefe4-0190-45b0-9a72-8d188c60204e",
+                            "id": "3e45908d-45ad-48fe-bbb0-a35cae4227b2",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3271,7 +4015,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3280,7 +4024,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3302,7 +4046,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3328,12 +4072,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "384df147-2da7-4843-93e4-8604eec766a1",
+                            "id": "1b45e319-3d61-41dd-897e-9ad975fa9672",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -3355,7 +4099,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3364,7 +4108,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3386,7 +4130,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3412,13 +4156,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "70989e7a-4227-4457-9254-0578c3089088",
-                            "name": "Internal Server Error",
+                            "id": "ee22f025-0a4f-43d7-bf93-d355f341714b",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -3439,7 +4183,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3448,7 +4192,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3470,7 +4214,127 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": 5847\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5e448ce1-8b9d-4f07-aa34-66e44bd33939",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "log"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3496,7 +4360,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3507,7 +4371,7 @@
                     }
                 },
                 {
-                    "id": "700e226e-93f2-422c-806b-dfe398555f34",
+                    "id": "6555bc5b-95cb-4fc6-89c3-6fbc0621e8b6",
                     "name": "Batch trace endpoint (mixed types)",
                     "request": {
                         "name": "Batch trace endpoint (mixed types)",
@@ -3534,7 +4398,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "disabled": false,
@@ -3543,7 +4407,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -3557,7 +4421,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -3569,7 +4433,7 @@
                     },
                     "response": [
                         {
-                            "id": "fdcbae1c-ec0e-4b3c-974a-f5fab4f9f9d0",
+                            "id": "26587770-ee35-4983-afef-9fb67995f712",
                             "name": "Batch processed. Inspect `results` for per-item status.\n`failed > 0` means at least one item errored — the others\nwere still recorded.",
                             "originalRequest": {
                                 "url": {
@@ -3591,7 +4455,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3600,7 +4464,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3622,7 +4486,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3664,14 +4528,41 @@
                                     },
                                     "key": "Idempotency-Original-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"error\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"tool\",\n      \"status\": \"error\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"tool\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0409ebda-977c-4a27-bb35-0022cc7d30d8",
+                            "id": "cb527948-4c17-4341-bb29-a484169ad033",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3693,7 +4584,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3702,7 +4593,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3724,7 +4615,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3750,12 +4641,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "79603fc9-19f6-4b59-abe3-9a9dcd45d8e1",
+                            "id": "2ced6922-8e41-4eab-9012-339bb1bf2a11",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3777,7 +4668,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3786,7 +4677,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3808,7 +4699,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3834,12 +4725,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "85fff81d-8b08-4db2-9125-b3777ecc4248",
+                            "id": "93a6b6b2-e43d-4263-853e-b67606e90c18",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3861,7 +4752,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3870,7 +4761,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3892,7 +4783,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3918,12 +4809,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f1254907-2e72-4d39-a1af-770ca594f79b",
+                            "id": "7e105239-4fde-4d7a-b32a-69c7c1b74f3c",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -3945,7 +4836,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -3954,7 +4845,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3976,7 +4867,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4002,13 +4893,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8bd6efb0-b51c-4c91-b767-b3881b7eeeef",
-                            "name": "Internal Server Error",
+                            "id": "c5d7872b-2f38-47d2-8ec6-12511ec9b67d",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -4029,7 +4920,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "disabled": false,
@@ -4038,7 +4929,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4060,7 +4951,127 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 8863\n      },\n      \"output\": {\n        \"key_0\": \"string\"\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": 6678.160485943975,\n        \"key_1\": 2306.0119949148448\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d60fc741-85ee-4acc-8ab8-c5daacd68e2b",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "traces",
+                                        "batch"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied idempotency token (Phase 3). When\npresent, the server caches the response under\n`(tenant, key)` for **24 hours**:\n\n- Same key + identical body → cached replay; the response\n  is returned without re-running side effects (DB inserts,\n  token charges). Replays carry `Idempotency-Replay: true`.\n- Same key + different body → `422 idempotency_key_conflict`.\n- Different (or missing) key → fresh execution, default\n  behaviour.\n\nTypical pattern: generate a UUID per logical client operation\nand pass it on every retry of that operation. Errors are NOT\ncached, so retrying a failed call with the same key naturally\nre-executes.\n\nSupported on `/v1/traces/llm`, `/v1/traces/tool`,\n`/v1/traces/handoff`, `/v1/traces/log`, and\n`/v1/traces/batch`.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Idempotency-Key",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4086,7 +5097,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4103,7 +5114,7 @@
             "description": "Conversation records (used by the Python SDK and for batch imports).",
             "item": [
                 {
-                    "id": "bec9311f-08fb-438d-be0f-a5fb22efd9ec",
+                    "id": "82e038ab-5e80-4fa9-a75d-05cb67995f33",
                     "name": "Upload conversation records (batch)",
                     "request": {
                         "name": "Upload conversation records (batch)",
@@ -4130,7 +5141,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -4144,7 +5155,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -4156,7 +5167,7 @@
                     },
                     "response": [
                         {
-                            "id": "160d41f4-638d-436d-bc8b-9735e2a55fca",
+                            "id": "bb035783-7b19-4c7a-85c2-0380dd842f38",
                             "name": "Records processed",
                             "originalRequest": {
                                 "url": {
@@ -4178,7 +5189,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4200,7 +5211,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4224,14 +5235,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": true,\n    \"key_1\": 4267,\n    \"key_2\": 3226.573465335095\n  }\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": 626.7520264454652,\n    \"key_1\": 3659\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "71ce5644-edf8-400d-b18d-9fd9c3ac5518",
+                            "id": "05029714-fad5-43f7-a6bf-6b7e4083ce68",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4253,7 +5291,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4275,7 +5313,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4301,12 +5339,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ca55f206-769b-4b30-8b4b-493c6ab44f4d",
+                            "id": "4e233f54-cc2f-4ae8-a2a1-7edc585f6448",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4328,7 +5366,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4350,7 +5388,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4376,12 +5414,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c17f5237-fc2c-425d-9877-6dee12d45a3c",
+                            "id": "297c5f88-c799-40e7-b751-3d3b62aa3267",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4403,7 +5441,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4425,7 +5463,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4451,13 +5489,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3322b51e-5354-43c3-8d48-3e522f873875",
-                            "name": "Internal Server Error",
+                            "id": "3c781db5-86b6-40ea-969e-3146471cf0f5",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -4478,7 +5516,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4500,7 +5538,118 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3385\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "299e817d-5f61-4e6e-a9a4-35cada2a4cf5",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4526,7 +5675,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4543,7 +5692,7 @@
             "description": "Operational log entries.",
             "item": [
                 {
-                    "id": "41a1cb13-c97d-4b91-9cbb-6a98547b97bb",
+                    "id": "a31934d3-6fa0-481c-9567-cd837a0f7eba",
                     "name": "Upload operational logs (batch)",
                     "request": {
                         "name": "Upload operational logs (batch)",
@@ -4570,7 +5719,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -4584,7 +5733,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
+                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -4596,7 +5745,7 @@
                     },
                     "response": [
                         {
-                            "id": "e5961036-e886-4000-8a73-6c4f40272b6a",
+                            "id": "9762b4ea-94f7-4b6f-a3a8-4269b47eb991",
                             "name": "Logs processed",
                             "originalRequest": {
                                 "url": {
@@ -4618,7 +5767,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4640,7 +5789,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4664,14 +5813,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\"\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": false\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "dee3bfb3-2e0f-4717-8b94-9a444626a012",
+                            "id": "b702091e-1b32-4a79-a02f-6a2337bdd2c3",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4693,7 +5869,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4715,7 +5891,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4741,12 +5917,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4c50c405-eb45-4533-90b2-0b500dfce99f",
+                            "id": "a01a77d2-e1eb-4024-91b0-d46a7e3e4f64",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4768,7 +5944,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4790,7 +5966,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4816,12 +5992,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "467787cc-6304-4e64-9864-5cdbb181730c",
+                            "id": "3eefc2b1-4a65-415c-a02d-664a897e2c78",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4843,7 +6019,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4865,7 +6041,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4891,13 +6067,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a844ab98-c00d-4d9c-bff4-7f45bb18bbbe",
-                            "name": "Internal Server Error",
+                            "id": "768a1268-4da4-4da6-8bd1-6b57b5728d8f",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -4918,7 +6094,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4940,7 +6116,118 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 8650,\n        \"key_1\": 1603.079107036458\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5bda742a-e481-4e41-9aaa-494d498edf15",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "upload"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4966,7 +6253,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4983,7 +6270,7 @@
             "description": "Read records and logs.",
             "item": [
                 {
-                    "id": "fd74a8cd-d2bd-435b-8bfc-1569f9691dc7",
+                    "id": "58624125-f870-41bb-8fdf-5b3934711b51",
                     "name": "Query conversation records",
                     "request": {
                         "name": "Query conversation records",
@@ -5006,7 +6293,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -5032,7 +6319,7 @@
                     },
                     "response": [
                         {
-                            "id": "518fdeeb-1922-42b9-956a-40ab6ad12131",
+                            "id": "b6eb062b-9e2f-41ca-9980-8133efb16a6a",
                             "name": "Records matching the query",
                             "originalRequest": {
                                 "url": {
@@ -5053,7 +6340,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5099,14 +6386,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"user\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 6983.5879070411165,\n            \"key_1\": 9495.87641521313\n          },\n          {\n            \"key_0\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"user\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 3492\n          },\n          {\n            \"key_0\": 7629,\n            \"key_1\": 6065,\n            \"key_2\": 4036.815064908904\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"teams\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": \"string\"\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": \"string\",\n            \"key_2\": true,\n            \"key_3\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 6802\n          },\n          {\n            \"key_0\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "aba5c676-9b3b-463e-a7ec-cdd37be5f6ea",
+                            "id": "a4fe969b-d31f-42ca-a301-e9791b074b0d",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5127,7 +6441,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5175,12 +6489,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "df819a83-0c07-412d-9b64-52145e328af1",
+                            "id": "ce778f9f-84e6-4c0d-92d2-5d5812e94582",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5201,7 +6515,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5249,12 +6563,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7ade7c88-312e-4d7f-be33-4b1cdc3e5f92",
+                            "id": "150dbeeb-bc45-4cab-991c-5a0081102961",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -5275,7 +6589,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5323,12 +6637,122 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "adff4da3-bcdb-4c82-a122-9069d2350284",
+                            "id": "c1a9ffa5-7ccc-4a25-89ab-85ec81329752",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "record_query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"query\": {\n    \"agent\": \"<string>\",\n    \"session_id\": \"<string>\",\n    \"start_date\": \"<dateTime>\",\n    \"end_date\": \"<dateTime>\",\n    \"limit\": 100,\n    \"offset\": 0\n  }\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7aa79756-6786-40ba-a0fe-46ffc433be4b",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5349,7 +6773,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5397,7 +6821,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5408,7 +6832,7 @@
                     }
                 },
                 {
-                    "id": "b21392a1-c956-4b81-8d5a-d787e47e6063",
+                    "id": "b72feaaf-eefe-4435-a0f0-6a56f569f28b",
                     "name": "Query log entries",
                     "request": {
                         "name": "Query log entries",
@@ -5432,7 +6856,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -5446,7 +6870,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -5458,7 +6882,7 @@
                     },
                     "response": [
                         {
-                            "id": "72b50461-7067-4060-8e97-4ba50c112d70",
+                            "id": "3472de87-09bf-4aff-ac28-3be848e960d3",
                             "name": "Logs matching the query",
                             "originalRequest": {
                                 "url": {
@@ -5480,7 +6904,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5502,7 +6926,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5526,14 +6950,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 5362,\n        \"key_1\": true,\n        \"key_2\": true\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 3250.963957547204,\n        \"key_1\": 7147\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2363890b-be35-4a2e-ad98-4a49a3ccb5ae",
+                            "id": "0c03feb1-cb60-4ea0-b8fa-b1604de66e2a",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5555,7 +7006,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5577,7 +7028,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5603,12 +7054,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0b6ac627-82a7-4476-8b3c-7fe2528c26a4",
+                            "id": "7505f1b4-1a6e-4f61-82c9-a27a7f790f28",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5630,7 +7081,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5652,7 +7103,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5678,12 +7129,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fcbd8eb5-8c53-4dce-83b4-e46c45c0afb5",
+                            "id": "b20b9b7d-4017-4fbb-92ad-31e5b261f2a6",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -5705,7 +7156,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5727,7 +7178,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5753,13 +7204,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5a785b8c-9283-45c3-b6eb-50b1351a2416",
-                            "name": "Internal Server Error",
+                            "id": "6b923262-514f-4644-9ff0-d61f9afe8fa4",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -5780,7 +7231,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5802,7 +7253,118 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5fbbb5ca-c742-43bb-9844-693b59f71e60",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "query"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5828,7 +7390,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5845,7 +7407,7 @@
             "description": "Bulk export with server-side pagination.",
             "item": [
                 {
-                    "id": "4b8cc088-31de-4db0-b881-e4a7f0d44e5a",
+                    "id": "06dd8f21-51d0-4a0b-8d3a-16d7e73786d7",
                     "name": "Export conversation records (JSON or CSV)",
                     "request": {
                         "name": "Export conversation records (JSON or CSV)",
@@ -5869,7 +7431,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -5895,7 +7457,7 @@
                     },
                     "response": [
                         {
-                            "id": "d3d026e8-e0ed-4e85-b126-4220187c253a",
+                            "id": "0632601c-206c-43f3-859d-a136d6dfc3d1",
                             "name": "Records exported",
                             "originalRequest": {
                                 "url": {
@@ -5917,7 +7479,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5963,14 +7525,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9469.721268734858\n          },\n          {\n            \"key_0\": \"string\",\n            \"key_1\": true,\n            \"key_2\": 2849,\n            \"key_3\": 9204\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 881.0815020854012\n          },\n          {\n            \"key_0\": 5167,\n            \"key_1\": false\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"teams\"\n    }\n  ]\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          },\n          {\n            \"key_0\": 1890,\n            \"key_1\": 5649\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4103.822011778756\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 9521.835087665508\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "61340330-2816-4228-9265-66dc57b6a314",
+                            "id": "585dd6e3-05fa-442a-97ca-22de1c6c0047",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5992,7 +7581,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6040,12 +7629,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d2920e58-4cce-4864-872e-1c0fbdbff440",
+                            "id": "a0424c8d-9631-425f-a362-69a3d3c4af45",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -6067,7 +7656,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6115,12 +7704,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1d361907-b308-49e4-9455-15ac2b5cd971",
+                            "id": "9b8b5be8-dfd1-415b-98a9-46b8f319ae2c",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -6142,7 +7731,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6190,12 +7779,123 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "af4bfe46-8a21-4f08-aa0f-a65d16b12320",
+                            "id": "5b3235d0-b00f-4615-a4b4-8515b8cb1d6b",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "records",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"agent\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "786d4cb0-09b4-4dd9-aa31-2424e1d4843d",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -6217,7 +7917,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6265,7 +7965,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -6276,7 +7976,7 @@
                     }
                 },
                 {
-                    "id": "5272e9af-32ba-4cc4-8e62-02561cd8fcef",
+                    "id": "23e70276-8b36-47e1-9a7f-946864aad90d",
                     "name": "Export logs (JSON or CSV)",
                     "request": {
                         "name": "Export logs (JSON or CSV)",
@@ -6300,7 +8000,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "8fyH3t[\"EOGhh"
+                                "value": "S{\"?K~on>dQ]W-'hT1^}"
                             },
                             {
                                 "key": "Content-Type",
@@ -6314,7 +8014,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -6326,7 +8026,7 @@
                     },
                     "response": [
                         {
-                            "id": "0b7c420e-b331-4003-8238-056bfee5c18b",
+                            "id": "c5e82e1a-3c44-4607-91c9-00475a463d16",
                             "name": "Logs exported",
                             "originalRequest": {
                                 "url": {
@@ -6348,7 +8048,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6370,7 +8070,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6394,14 +8094,41 @@
                                     },
                                     "key": "X-Request-ID",
                                     "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false,\n        \"key_1\": 5905.068480794311\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 5083.693839192576,\n        \"key_1\": 5020.4676053592275\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 2407.929988474907,\n        \"key_1\": \"string\",\n        \"key_2\": true\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\",\n        \"key_1\": true\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "04cd7014-ae34-44ba-b9fb-25a807d149a9",
+                            "id": "fe1a5941-b0d4-4978-8cd4-7c76857c94f3",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -6423,7 +8150,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6445,7 +8172,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6471,12 +8198,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "71c572eb-c774-466e-9e2d-cad6cc9d261d",
+                            "id": "b83d6d2c-307b-48ea-87e2-8ed22d419515",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -6498,7 +8225,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6520,7 +8247,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6546,12 +8273,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9de234c1-4ae4-4917-9f21-f316342aa288",
+                            "id": "81162572-fda0-4091-8e49-1ed21e9fc61f",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -6573,7 +8300,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6595,7 +8322,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6621,13 +8348,13 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "418c6bb8-153f-43a7-b727-a92f64c17031",
-                            "name": "Internal Server Error",
+                            "id": "cf213da7-fd3e-44a1-99fc-3687b2c0bf5d",
+                            "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
                                     "path": [
@@ -6648,7 +8375,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "8fyH3t[\"EOGhh"
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6670,7 +8397,118 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"error\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-Request-ID",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Limit",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Remaining",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "X-RateLimit-Reset",
+                                    "value": ""
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "Retry-After",
+                                    "value": ""
+                                }
+                            ],
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "78257d17-563f-4946-9632-ad600a529896",
+                            "name": "Internal Server Error",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "logs",
+                                        "export"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "disabled": false,
+                                        "description": {
+                                            "content": "Optional client-supplied request correlation ID. If provided,\nthe server preserves the value in the response `X-Request-ID`\nheader (round-trip). If omitted, the server generates a UUIDv4.\nUseful for distributed traces and support correlation.\n",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "X-Request-ID",
+                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                    },
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "description": {
+                                            "content": "Added as a part of security scheme: bearer",
+                                            "type": "text/plain"
+                                        },
+                                        "key": "Authorization",
+                                        "value": "Bearer <token>"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6696,7 +8534,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"idempotency_key_conflict\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -6727,7 +8565,7 @@
         }
     ],
     "info": {
-        "_postman_id": "73b9790c-d32e-416a-972a-527475be179e",
+        "_postman_id": "76dc2a44-17b9-46bd-be6e-e9e6a2bda677",
         "name": "MonkAI Trace API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
## O que foi feito

Companion docs do que ja esta deployado em prod (monkai-api v144) — [BeMonkAI/monkai-agent-hub#26](https://github.com/BeMonkAI/monkai-agent-hub/pull/26). **Fecha a Fase 3 do API Roadmap.**

### \`docs/openapi.yaml\`
- **Novos response headers**: \`RateLimitLimit\`, \`RateLimitRemaining\`, \`RateLimitReset\`, \`RetryAfter\` — wired no \`200\` de **13 endpoints** (todos exceto /health)
- **Nova response \`TooManyRequests\`** (429) com envelope estruturado + todos os rate-limit headers + Retry-After. Wired nos mesmos 13 endpoints.
- **Novo error code** \`rate_limit_exceeded\` no enum canonico

### \`docs/http_rest_api.md\`
- Nova secao \"Rate Limiting\" com:
  - Tabela bucket × endpoint × limite/min
  - Lista de headers (legacy + RFC draft)
  - Exemplo completo de 429
  - Pattern JS de retry com Retry-After

### \`docs/MIGRATION.md\`
- Nova secao **\"6. Handle rate limits\"**
- Summary table atualizada com 6a linha

### \`docs/API_CHANGELOG.md\`
- Nova entry \`[v1.4] — 2026-05-02\` documentando feature
- **\"Phase 3 of the API roadmap is complete\"** — restante so o custom domain de Fase 2

### \`docs/postman_collection.json\`
- Regenerado (mantido 7 folders / 15 requests)

## Como testar

\`\`\`bash
.venv/bin/python -c \"from openapi_spec_validator import validate; import yaml; validate(yaml.safe_load(open('docs/openapi.yaml')))\"
npx --yes @redocly/cli@latest lint docs/openapi.yaml --config docs/redocly.yaml

# Smoke contra prod (versao 144):
TOKEN=tk_xxx
curl -i -X POST -H \"Authorization: Bearer \$TOKEN\" -H \"Content-Type: application/json\" \\
  -d '{\"namespace\":\"smoke\",\"user_id\":\"x\"}' \\
  https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1/sessions/get-or-create

# Esperado: response inclui X-RateLimit-Limit/Remaining/Reset
\`\`\`

## Checklist

- [x] OpenAPI 3.1 valido (14 paths, 41 schemas, +4 headers + 1 response)
- [x] Redocly zero warnings
- [x] Postman regenerado (7/15)
- [x] Mudanca 100% docs (zero codigo runtime)
- [x] Reflete prod (v144)
- [x] **Fase 3 do API Roadmap fica COMPLETA** apos este merge

## Apos merge

Issue [#12](https://github.com/BeMonkAI/monkai-trace/issues/12) pode ser fechada. Restante do API Roadmap:
- Issue [#11](https://github.com/BeMonkAI/monkai-trace/issues/11) — apenas custom domain remaining
- Issue [#21](https://github.com/BeMonkAI/monkai-trace/issues/21) — custom domain do site de docs

Refs #12 (closes after merge)