### PR TITLE
fix(docs): correct custom domain to trace-docs.monkai.com.br

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official Python client for [MonkAI](https://monkai.ai) - Monitor, analyze, and o
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-> 📖 **REST API reference**: [trace-docs.monkai.ai](https://trace-docs.monkai.ai) — interactive ReDoc with curl/Node/Python samples per endpoint *(also at [bemonkai.github.io/monkai-trace](https://bemonkai.github.io/monkai-trace/))*
+> 📖 **REST API reference**: [trace-docs.monkai.com.br](https://trace-docs.monkai.com.br) — interactive ReDoc with curl/Node/Python samples per endpoint *(also at [bemonkai.github.io/monkai-trace](https://bemonkai.github.io/monkai-trace/))*
 > · [Migration guide](docs/MIGRATION.md)
 > · [API changelog](docs/API_CHANGELOG.md)
 > · [OpenAPI spec](docs/openapi.yaml)

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-trace-docs.monkai.ai
+trace-docs.monkai.com.br


### PR DESCRIPTION
Follow-up de [#26](https://github.com/BeMonkAI/monkai-trace/pull/26). O CNAME anterior apontava pra \`trace-docs.monkai.ai\` baseado em assumption errada — a conta GoDaddy nao possui \`.ai\`, so \`.com.br\` e \`.com\` (\`monkai.com.br\`, \`monkaihub.com\`, etc).

Corrige pra \`trace-docs.monkai.com.br\` — subdomain especifico na marca publica, deixa \`docs.monkai.com.br\` curto livre pra eventual portal agregado.

Apos merge: crio CNAME no DNS via GoDaddy API + configuro Pages settings.

Refs #21