### PR TITLE
docs(api): promote api.monkai.com.br/trace/v1 as primary (closes #11)

### DIFF
--- a/docs/API_CHANGELOG.md
+++ b/docs/API_CHANGELOG.md
@@ -12,8 +12,27 @@ keep working during a deprecation window.
 
 ## [Unreleased]
 
-### Planned (Phase 2 — remaining)
-- Custom domain `https://api.monkai.ai/trace/v1`.
+_All Phase 2 and Phase 3 items shipped. The roadmap is currently **complete**._
+
+## [v1.5] — 2026-05-03
+
+### Added
+- **Custom domain** `https://api.monkai.com.br/trace/v1`. Closes
+  the last item of Phase 2 ([#11](https://github.com/BeMonkAI/monkai-trace/issues/11)).
+  - Implemented as a Vercel Edge proxy (~80-line stateless handler)
+    in [`vercel-proxy/`](../vercel-proxy/) that forwards `/trace/*`
+    to the underlying Supabase edge function. Same Web Standards
+    code we already use; portable to any other edge platform.
+  - DNS: CNAME `api.monkai.com.br` → `cname.vercel-dns.com`.
+  - TLS: Let's Encrypt provisioned automatically by Vercel; auto-renewed.
+  - Reference: [BeMonkAI/monkai-trace#29](https://github.com/BeMonkAI/monkai-trace/pull/29) (proxy code).
+- **OpenAPI server entries reordered**: `https://api.monkai.com.br/trace/v1`
+  is now the recommended primary; the direct Supabase URLs are
+  retained as fallbacks for clients that pin to them.
+
+### Notes
+- Future migration off Vercel changes only the proxy upstream;
+  clients keep the same `api.monkai.com.br/trace/v1/*` URLs.
 
 ## [v1.4] — 2026-05-02
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -27,12 +27,12 @@ info:
     url: https://github.com/BeMonkAI/monkai-trace/blob/main/LICENSE
 
 servers:
+  - url: https://api.monkai.com.br/trace/v1
+    description: Production — recommended for all clients (custom domain via Vercel Edge proxy)
   - url: https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1
-    description: Production — versioned routes (recommended for new clients)
+    description: Production — direct Supabase URL (still works; prefer the custom domain above)
   - url: https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api
-    description: Production — legacy unversioned routes (still supported)
-  - url: https://api.monkai.ai/trace/v1
-    description: Production (planned custom domain — Phase 2)
+    description: Production — legacy unversioned Supabase URL (still supported)
 
 tags:
   - name: Health
@@ -86,18 +86,18 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl "https://api.monkai.ai/trace/v1/health"
+            curl "https://api.monkai.com.br/trace/v1/health"
         - lang: JavaScript
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies, no auth required
-            const res = await fetch("https://api.monkai.ai/trace/v1/health", { method: "GET" });
+            const res = await fetch("https://api.monkai.com.br/trace/v1/health", { method: "GET" });
             console.log(res.status, res.headers.get("x-request-id"));
         - lang: Python
           label: Python
           source: |
             import requests
-            r = requests.get("https://api.monkai.ai/trace/v1/health")
+            r = requests.get("https://api.monkai.com.br/trace/v1/health")
             print(r.status_code, r.headers["x-request-id"])
     head:
       tags: [Health]
@@ -175,7 +175,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/sessions/create" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/sessions/create" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -184,7 +184,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/sessions/create", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/sessions/create", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -198,7 +198,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/sessions/create",
+                "https://api.monkai.com.br/trace/v1/sessions/create",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"namespace":"my-agent","user_id":"5521999998888","inactivity_timeout":300},
             )
@@ -255,7 +255,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/sessions/get-or-create" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/sessions/get-or-create" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -264,7 +264,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/sessions/get-or-create", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/sessions/get-or-create", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -278,7 +278,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/sessions/get-or-create",
+                "https://api.monkai.com.br/trace/v1/sessions/get-or-create",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"namespace":"my-agent","user_id":"5521999998888"},
             )
@@ -335,7 +335,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/traces/llm" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/traces/llm" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -344,7 +344,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/traces/llm", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/traces/llm", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -358,7 +358,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/traces/llm",
+                "https://api.monkai.com.br/trace/v1/traces/llm",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"Hi"}]},"output":{"content":"Hello"}},
             )
@@ -414,7 +414,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/traces/tool" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/traces/tool" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -423,7 +423,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/traces/tool", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/traces/tool", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -437,7 +437,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/traces/tool",
+                "https://api.monkai.com.br/trace/v1/traces/tool",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},
             )
@@ -493,7 +493,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/traces/handoff" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/traces/handoff" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -502,7 +502,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/traces/handoff", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/traces/handoff", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -516,7 +516,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/traces/handoff",
+                "https://api.monkai.com.br/trace/v1/traces/handoff",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"session_id":"sess_abc","from_agent":"triage","to_agent":"sales","reason":"intent matched"},
             )
@@ -577,7 +577,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/traces/log" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/traces/log" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -586,7 +586,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/traces/log", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/traces/log", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -600,7 +600,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/traces/log",
+                "https://api.monkai.com.br/trace/v1/traces/log",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"session_id":"sess_abc","level":"info","message":"step 5 done"},
             )
@@ -673,7 +673,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/traces/batch" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/traces/batch" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -682,7 +682,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/traces/batch", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/traces/batch", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -696,7 +696,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/traces/batch",
+                "https://api.monkai.com.br/trace/v1/traces/batch",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"traces":[{"type":"llm","session_id":"sess_abc","model":"gpt-4","input":{"messages":[{"role":"user","content":"hi"}]},"output":{"content":"hello"}},{"type":"tool","session_id":"sess_abc","tool_name":"get_weather","arguments":{"city":"SP"},"result":{"temp":24}},{"type":"log","session_id":"sess_abc","level":"info","message":"done"}]},
             )
@@ -750,7 +750,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/records/upload" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/records/upload" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -759,7 +759,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/records/upload", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/records/upload", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -773,7 +773,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/records/upload",
+                "https://api.monkai.com.br/trace/v1/records/upload",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"records":[{"namespace":"my-agent","agent":"bot","msg":[{"role":"user","content":"hi"}]}]},
             )
@@ -826,7 +826,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/logs/upload" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/logs/upload" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -835,7 +835,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/logs/upload", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/logs/upload", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -849,7 +849,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/logs/upload",
+                "https://api.monkai.com.br/trace/v1/logs/upload",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"logs":[{"namespace":"my-agent","level":"info","message":"hi"}]},
             )
@@ -898,7 +898,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/record_query" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/record_query" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -907,7 +907,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/record_query", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/record_query", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -921,7 +921,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/record_query",
+                "https://api.monkai.com.br/trace/v1/record_query",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"namespace":"my-agent","query":{"limit":50}},
             )
@@ -973,7 +973,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/logs/query" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/logs/query" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -982,7 +982,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/logs/query", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/logs/query", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -996,7 +996,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/logs/query",
+                "https://api.monkai.com.br/trace/v1/logs/query",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"namespace":"my-agent","level":"error","limit":100},
             )
@@ -1049,7 +1049,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/records/export" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/records/export" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -1058,7 +1058,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/records/export", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/records/export", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -1072,7 +1072,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/records/export",
+                "https://api.monkai.com.br/trace/v1/records/export",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"namespace":"my-agent","format":"json"},
             )
@@ -1125,7 +1125,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl -X POST "https://api.monkai.ai/trace/v1/logs/export" \
+            curl -X POST "https://api.monkai.com.br/trace/v1/logs/export" \
               -H "Authorization: Bearer $MONKAI_TRACER_TOKEN" \
               -H "Content-Type: application/json" \
               -H "X-Request-ID: $(uuidgen)" \
@@ -1134,7 +1134,7 @@ paths:
           label: Node.js
           source: |
             // Node.js 18+ — no dependencies
-            const res = await fetch("https://api.monkai.ai/trace/v1/logs/export", {
+            const res = await fetch("https://api.monkai.com.br/trace/v1/logs/export", {
               method: "POST",
               headers: {
                 "Authorization": `Bearer ${process.env.MONKAI_TRACER_TOKEN}`,
@@ -1148,7 +1148,7 @@ paths:
           source: |
             import os, requests
             r = requests.post(
-                "https://api.monkai.ai/trace/v1/logs/export",
+                "https://api.monkai.com.br/trace/v1/logs/export",
                 headers={"Authorization": f"Bearer {os.environ['MONKAI_TRACER_TOKEN']}"},
                 json={"namespace":"my-agent","format":"csv"},
             )

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -5,7 +5,7 @@
             "description": "Liveness check (no auth required).",
             "item": [
                 {
-                    "id": "9093472e-6611-4589-868f-9a045bcc6c48",
+                    "id": "a4d33413-2be6-4760-b92b-63ad202419db",
                     "name": "Liveness check",
                     "request": {
                         "name": "Liveness check",
@@ -35,7 +35,7 @@
                     },
                     "response": [
                         {
-                            "id": "86b70d9f-9170-4ed5-a81a-9596ca9641c2",
+                            "id": "bdbd6610-3391-4164-92c1-ef87b7d53cbc",
                             "name": "Service is responsive",
                             "originalRequest": {
                                 "url": {
@@ -87,7 +87,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9ea6faa5-2c7d-4e53-bd66-8ef8bf73b86c",
+                            "id": "bbfd30bf-2cb9-4c24-b4ca-f67849149f98",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -134,7 +134,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -145,7 +145,7 @@
                     }
                 },
                 {
-                    "id": "0e02b9d9-af70-4119-9b0f-3fe2f9fef4ad",
+                    "id": "fa13ee23-5541-4f05-822b-c8ce120603d4",
                     "name": "Liveness check (HEAD variant)",
                     "request": {
                         "name": "Liveness check (HEAD variant)",
@@ -175,7 +175,7 @@
                     },
                     "response": [
                         {
-                            "id": "244c5384-0466-4a2a-b303-2a918c0c8672",
+                            "id": "3aca3462-77f5-4e60-9362-d42062570757",
                             "name": "Service is responsive (no body)",
                             "originalRequest": {
                                 "url": {
@@ -218,7 +218,7 @@
                             "_postman_previewlanguage": "text"
                         },
                         {
-                            "id": "4b66618d-3fac-41cb-a04a-36f86c06f008",
+                            "id": "6b08063f-fd7c-4cf3-bf01-98081d1a1004",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -265,7 +265,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -282,7 +282,7 @@
             "description": "Manage conversation sessions.",
             "item": [
                 {
-                    "id": "2ea16650-0f96-443e-9688-0f6b60a8acc4",
+                    "id": "c6423ec3-27b4-42c9-9654-9d07cfab7939",
                     "name": "Create a new session",
                     "request": {
                         "name": "Create a new session",
@@ -309,7 +309,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -323,7 +323,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -335,7 +335,7 @@
                     },
                     "response": [
                         {
-                            "id": "9784a3c0-5696-4854-aa04-de5d5d57e0ee",
+                            "id": "88a9d15a-62dc-4c2f-9754-08e7caef50d8",
                             "name": "Session created",
                             "originalRequest": {
                                 "url": {
@@ -357,7 +357,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -379,7 +379,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -432,12 +432,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": false\n  }\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 511,\n    \"key_1\": 2869.012086783137\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "501a202f-c78a-4eb8-9a59-422de7d2e2d8",
+                            "id": "d44a322a-3b29-42ca-bef1-b66cf7679bf2",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -459,7 +459,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -481,7 +481,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -507,12 +507,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2cf53dec-2dc0-446e-83b1-506e23df37be",
+                            "id": "a6d76af1-f55c-4025-a269-9e3f06f46553",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -534,7 +534,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -556,7 +556,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -582,12 +582,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8c85ab81-b83a-45f7-905c-1d16b048290e",
+                            "id": "e0bef849-af8b-49aa-b9c7-e18df6cfe06d",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -609,7 +609,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -631,7 +631,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -657,12 +657,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3f29e7c3-8bc0-4bc4-b201-86964cdfedc9",
+                            "id": "da4b08f9-f70d-4a81-8315-557c4601f983",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -684,7 +684,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -706,7 +706,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -768,12 +768,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "27e971c5-852a-4ae4-95d6-3e5d9173da31",
+                            "id": "a067b6af-656d-41a0-8f26-df627c71f42f",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -795,7 +795,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -817,7 +817,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": \"string\"\n  }\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": 120,\n  \"metadata\": {\n    \"key_0\": 9999,\n    \"key_1\": 7724.720273801805\n  }\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -843,7 +843,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -854,7 +854,7 @@
                     }
                 },
                 {
-                    "id": "4fee1218-1e93-4ec2-a688-cfcbe5467f49",
+                    "id": "bc6ad7dd-1f45-451f-803b-9602bfbaed03",
                     "name": "Get an active session or create a new one",
                     "request": {
                         "name": "Get an active session or create a new one",
@@ -881,7 +881,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -907,7 +907,7 @@
                     },
                     "response": [
                         {
-                            "id": "f57bc174-b248-49ae-91bc-14aa9075e401",
+                            "id": "70c6f513-7e99-47b9-b20c-250fc215580b",
                             "name": "Session returned (existing or new)",
                             "originalRequest": {
                                 "url": {
@@ -929,7 +929,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1004,12 +1004,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2983.6652259357575\n  },\n  \"reused\": \"<boolean>\"\n}",
+                            "body": "{\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"created_at\": \"<dateTime>\",\n  \"user_id\": \"<string>\",\n  \"inactivity_timeout\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 7907.3973433333185\n  },\n  \"reused\": \"<boolean>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9b6dd6bd-87fb-4125-8518-e0c4d52fc416",
+                            "id": "b13c1045-cb36-423a-8f0d-e247daa64af1",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1031,7 +1031,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1079,12 +1079,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0c238756-362a-4d76-8f97-7cb50472720a",
+                            "id": "a8614710-3638-49f7-ade5-d5575621bbd4",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1106,7 +1106,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1154,12 +1154,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5e3e2e9d-e5cf-471e-a5d6-9c7e8b5d24ca",
+                            "id": "f56e2a5c-61e0-4bec-875c-3d9d1b582bc1",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1181,7 +1181,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1229,12 +1229,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fd8bb8bd-5590-4e33-b2bd-4b636282ea4d",
+                            "id": "05c632c9-6da9-4213-930d-2613b2305c09",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -1256,7 +1256,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1340,12 +1340,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "865c0f34-fdae-423e-9316-eb354a7c250a",
+                            "id": "72383710-f9c4-4b69-a40a-4b578122193e",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -1367,7 +1367,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1415,7 +1415,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -1432,7 +1432,7 @@
             "description": "Record fine-grained events. Preferred for HTTP clients in any language.",
             "item": [
                 {
-                    "id": "73999b24-2c2b-42a4-b8d3-0aeb817fec92",
+                    "id": "1886d61b-b1dc-4d80-ae6d-9bc077c58a6e",
                     "name": "Trace an LLM call",
                     "request": {
                         "name": "Trace an LLM call",
@@ -1456,7 +1456,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "disabled": false,
@@ -1465,7 +1465,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -1479,7 +1479,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -1491,7 +1491,7 @@
                     },
                     "response": [
                         {
-                            "id": "00578c00-f931-40ae-bcb9-1a5746239b36",
+                            "id": "9b14e699-8e97-4136-b2ed-d96ad802b714",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -1513,7 +1513,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -1522,7 +1522,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1544,7 +1544,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1620,7 +1620,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "49966501-c16a-4d1f-9145-5e5802231e66",
+                            "id": "72197485-4239-4e54-a19d-30b91ba6f504",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -1642,7 +1642,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -1651,7 +1651,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1673,7 +1673,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1699,12 +1699,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7aacd671-8f72-41b1-8b96-944891fcca69",
+                            "id": "328524c0-d1a6-4f4e-9593-5d7546b08707",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -1726,7 +1726,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -1735,7 +1735,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1757,7 +1757,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1783,12 +1783,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "11de4ab6-e352-4b16-a675-e3a9a9cac4d2",
+                            "id": "ac98400d-01cb-4262-ad59-e2a5993825e5",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -1810,7 +1810,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -1819,7 +1819,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1841,7 +1841,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1867,12 +1867,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "200cd9f0-8294-426b-a257-0053f724d11e",
+                            "id": "9a772bd5-2fb7-4355-b86d-a067aaeb8e88",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -1894,7 +1894,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -1903,7 +1903,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -1925,7 +1925,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -1951,12 +1951,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5dc4abed-b5fb-43c7-a937-8bc07cfe543b",
+                            "id": "dc1732dc-a46e-4c65-88d2-b145c620ed1c",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -1978,7 +1978,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -1987,7 +1987,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2009,7 +2009,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2071,12 +2071,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6f1faca5-7e69-48f0-85c5-2422d435acd7",
+                            "id": "e524f528-f5d7-4798-a30c-4d3f635dca25",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -2098,7 +2098,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2107,7 +2107,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2129,7 +2129,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 3447.161208838474\n  },\n  \"output\": {\n    \"key_0\": \"string\"\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 2705.9766946532636,\n    \"key_1\": 9651,\n    \"key_2\": 5181.474298970341,\n    \"key_3\": 2339\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"model\": \"<string>\",\n  \"provider\": \"<string>\",\n  \"input\": {\n    \"key_0\": 4991.078493722391,\n    \"key_1\": 9349.710000940857,\n    \"key_2\": 9255,\n    \"key_3\": true\n  },\n  \"output\": {\n    \"key_0\": 2897,\n    \"key_1\": false\n  },\n  \"latency_ms\": \"<integer>\",\n  \"metadata\": {\n    \"key_0\": 6371,\n    \"key_1\": false\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"web\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2155,7 +2155,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2166,7 +2166,7 @@
                     }
                 },
                 {
-                    "id": "6ee3c98b-0682-423a-9bed-7bc7e2dfb0b3",
+                    "id": "66d0be80-360d-4d87-8351-9db153a75348",
                     "name": "Trace a tool/function call",
                     "request": {
                         "name": "Trace a tool/function call",
@@ -2190,7 +2190,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "disabled": false,
@@ -2199,7 +2199,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -2213,7 +2213,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2225,7 +2225,7 @@
                     },
                     "response": [
                         {
-                            "id": "c5f06490-ecd7-4267-ae3a-6219386146c3",
+                            "id": "2696dbd3-4047-4444-a100-e8debde43939",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -2247,7 +2247,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2256,7 +2256,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2278,7 +2278,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2354,7 +2354,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b48d564c-a374-43f0-aabb-7fb0dc585b2e",
+                            "id": "26160a63-b4ba-4d35-b231-7bcf94518732",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -2376,7 +2376,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2385,7 +2385,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2407,7 +2407,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2433,12 +2433,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8be06318-b4d2-42a0-8249-f672639e4fc6",
+                            "id": "f4fe5fbf-5704-4f10-964a-ed13b608928d",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -2460,7 +2460,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2469,7 +2469,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2491,7 +2491,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2517,12 +2517,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "42ac8d6d-c5c5-463a-a2c4-654512c450d4",
+                            "id": "68f40116-b82d-4555-9c8c-5c44d67883b5",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -2544,7 +2544,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2553,7 +2553,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2575,7 +2575,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2601,12 +2601,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "77eb1a5a-9c13-4984-b3fa-dfe675853d21",
+                            "id": "206e534a-521a-4e3e-ac0e-60a2e9917a14",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -2628,7 +2628,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2637,7 +2637,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2659,7 +2659,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2685,12 +2685,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "432491b9-aae3-42fa-b6a0-de6a2d76684e",
+                            "id": "2df6bb71-4073-4379-9a35-911da53e1c46",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -2712,7 +2712,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2721,7 +2721,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2743,7 +2743,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2805,12 +2805,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2227fea9-7026-4c6d-b0cf-397d7c06884e",
+                            "id": "76138378-b235-449b-96fe-6b78a7f9209c",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -2832,7 +2832,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2841,7 +2841,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -2863,7 +2863,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": 3090,\n    \"key_1\": 5378.602932978358\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7559,\n    \"key_1\": 8591.536434268959,\n    \"key_2\": 7002,\n    \"key_3\": true\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"tool_name\": \"<string>\",\n  \"arguments\": {\n    \"key_0\": true\n  },\n  \"result\": \"\",\n  \"latency_ms\": \"<integer>\",\n  \"agent\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 7848.729046980613,\n    \"key_1\": 7646.514168330572\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"telegram\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -2889,7 +2889,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -2900,7 +2900,7 @@
                     }
                 },
                 {
-                    "id": "228947da-162f-4dcb-ac43-ca6f446dcdae",
+                    "id": "4b658422-069a-4a14-9f42-99f08e19f63d",
                     "name": "Trace an agent-to-agent handoff",
                     "request": {
                         "name": "Trace an agent-to-agent handoff",
@@ -2924,7 +2924,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "disabled": false,
@@ -2933,7 +2933,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -2947,7 +2947,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                            "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -2959,7 +2959,7 @@
                     },
                     "response": [
                         {
-                            "id": "33fb38da-2959-4abb-a30f-9fed63a9cb80",
+                            "id": "dd1c6047-f83a-4fda-9e40-1542eda0a66b",
                             "name": "Trace recorded",
                             "originalRequest": {
                                 "url": {
@@ -2981,7 +2981,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -2990,7 +2990,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3012,7 +3012,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3088,7 +3088,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "700f65e0-5203-4feb-82f6-5772ff0291ae",
+                            "id": "15991363-294e-4adf-af95-4de9ef969eb0",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3110,7 +3110,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3119,7 +3119,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3141,7 +3141,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3167,12 +3167,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "99b2a9cf-8f8b-4a36-9c18-2200ddc99e4e",
+                            "id": "973ca3dd-6e2e-45c0-89a9-d9f760f6ee00",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3194,7 +3194,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3203,7 +3203,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3225,7 +3225,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3251,12 +3251,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "64ac2530-7c87-49a9-a025-fd36491207e6",
+                            "id": "df6cfbda-b5ae-4cd4-8d97-178e2eac42f4",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -3278,7 +3278,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3287,7 +3287,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3309,7 +3309,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3335,12 +3335,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "52ad466a-167f-4c5a-a9d9-983b42a1a1d3",
+                            "id": "e34127d5-e901-4d57-81b5-23f3304e121b",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -3362,7 +3362,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3371,7 +3371,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3393,7 +3393,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3419,12 +3419,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "36716339-9994-44f1-bb10-1e8eff21c967",
+                            "id": "b609dc59-d7f4-4eca-8ccc-1ea19052ef85",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -3446,7 +3446,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3455,7 +3455,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3477,7 +3477,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3539,12 +3539,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "087723bd-90e5-459a-aea6-3b939d87c598",
+                            "id": "4d8f14c2-365c-4fa1-bb08-fa16419e55c9",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3566,7 +3566,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3575,7 +3575,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3597,7 +3597,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": \"string\",\n    \"key_1\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"slack\"\n}",
+                                    "raw": "{\n  \"session_id\": \"<string>\",\n  \"from_agent\": \"<string>\",\n  \"to_agent\": \"<string>\",\n  \"reason\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 4961,\n    \"key_1\": 8820,\n    \"key_2\": \"string\"\n  },\n  \"timestamp\": \"<dateTime>\",\n  \"external_user_id\": \"<string>\",\n  \"external_user_name\": \"<string>\",\n  \"external_user_channel\": \"whatsapp\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3623,7 +3623,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -3634,7 +3634,7 @@
                     }
                 },
                 {
-                    "id": "5247b69a-99ed-4d37-ba5e-ded4174b8c26",
+                    "id": "d307d708-7e51-4511-a147-319564bb1ba0",
                     "name": "Trace a log entry",
                     "request": {
                         "name": "Trace a log entry",
@@ -3661,7 +3661,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "disabled": false,
@@ -3670,7 +3670,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -3684,7 +3684,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                            "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -3696,7 +3696,7 @@
                     },
                     "response": [
                         {
-                            "id": "0d8cc4b8-28fa-4e73-b3b5-af7dd9799990",
+                            "id": "1de45855-a7a8-4860-8a71-16ec31bdb878",
                             "name": "Log recorded",
                             "originalRequest": {
                                 "url": {
@@ -3718,7 +3718,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3727,7 +3727,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3749,7 +3749,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3825,7 +3825,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d7ee93c2-84c0-473d-8fe3-387fa9671e7d",
+                            "id": "eafaf636-cf8f-409d-ad6b-9e434594524d",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -3847,7 +3847,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3856,7 +3856,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3878,7 +3878,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3904,12 +3904,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "85a1a0f7-6335-4a78-8041-7a67b38a2f5a",
+                            "id": "2d7f6e28-ed1f-4600-80fe-208e9f2766cc",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -3931,7 +3931,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -3940,7 +3940,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -3962,7 +3962,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -3988,12 +3988,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3e45908d-45ad-48fe-bbb0-a35cae4227b2",
+                            "id": "614e911d-ed02-4ba5-8cfd-7c9fc05c9b29",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4015,7 +4015,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4024,7 +4024,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4046,7 +4046,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4072,12 +4072,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1b45e319-3d61-41dd-897e-9ad975fa9672",
+                            "id": "35a8b07d-f6be-420d-aaa8-1f23068908ff",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -4099,7 +4099,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4108,7 +4108,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4130,7 +4130,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4156,12 +4156,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ee22f025-0a4f-43d7-bf93-d355f341714b",
+                            "id": "59afbdf4-ace4-41a1-be5e-548bbdf08216",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -4183,7 +4183,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4192,7 +4192,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4214,7 +4214,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4276,12 +4276,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5e448ce1-8b9d-4f07-aa34-66e44bd33939",
+                            "id": "075120de-2d63-435d-8928-5bd270a60604",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -4303,7 +4303,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4312,7 +4312,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4334,7 +4334,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": true\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
+                                    "raw": "{\n  \"message\": \"<string>\",\n  \"session_id\": \"<string>\",\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"metadata\": {\n    \"key_0\": 1786.5483105408896,\n    \"key_1\": 6058.080313546214\n  },\n  \"timestamp\": \"<dateTime>\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4360,7 +4360,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -4371,7 +4371,7 @@
                     }
                 },
                 {
-                    "id": "6555bc5b-95cb-4fc6-89c3-6fbc0621e8b6",
+                    "id": "0da20d66-ee4b-404d-ab32-b184ebc1b077",
                     "name": "Batch trace endpoint (mixed types)",
                     "request": {
                         "name": "Batch trace endpoint (mixed types)",
@@ -4398,7 +4398,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "disabled": false,
@@ -4407,7 +4407,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "Idempotency-Key",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -4421,7 +4421,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -4433,7 +4433,7 @@
                     },
                     "response": [
                         {
-                            "id": "26587770-ee35-4983-afef-9fb67995f712",
+                            "id": "20d7095b-59f3-4430-9c75-e237f7e88aa6",
                             "name": "Batch processed. Inspect `results` for per-item status.\n`failed > 0` means at least one item errored — the others\nwere still recorded.",
                             "originalRequest": {
                                 "url": {
@@ -4455,7 +4455,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4464,7 +4464,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4486,7 +4486,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4557,12 +4557,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"tool\",\n      \"status\": \"ok\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"success\": \"<boolean>\",\n  \"total\": \"<integer>\",\n  \"succeeded\": \"<integer>\",\n  \"failed\": \"<integer>\",\n  \"results\": [\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"log\",\n      \"status\": \"error\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    },\n    {\n      \"index\": \"<integer>\",\n      \"type\": \"tool\",\n      \"status\": \"error\",\n      \"result\": {\n        \"success\": \"<boolean>\",\n        \"trace_type\": \"<string>\",\n        \"tokens\": {\n          \"input\": \"<integer>\",\n          \"output\": \"<integer>\"\n        }\n      },\n      \"error\": {\n        \"code\": \"<string>\",\n        \"message\": \"<string>\"\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cb527948-4c17-4341-bb29-a484169ad033",
+                            "id": "a14cd1bd-67e5-4962-9afc-0dfdf80a20c0",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -4584,7 +4584,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4593,7 +4593,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4615,7 +4615,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4641,12 +4641,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2ced6922-8e41-4eab-9012-339bb1bf2a11",
+                            "id": "a6081a9a-470a-4c4c-b408-a72592769e12",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -4668,7 +4668,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4677,7 +4677,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4699,7 +4699,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4725,12 +4725,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "93a6b6b2-e43d-4263-853e-b67606e90c18",
+                            "id": "305d197f-eea7-4cce-ae51-9c3f4d8c1af0",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -4752,7 +4752,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4761,7 +4761,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4783,7 +4783,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4809,12 +4809,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7e105239-4fde-4d7a-b32a-69c7c1b74f3c",
+                            "id": "8d5c321e-d1ff-4dd8-9166-89f5ae866a46",
                             "name": "Conflict — typically `idempotency_key_conflict`, raised when an\n`Idempotency-Key` is reused with a different request body. Pick\na new key or fix the body.",
                             "originalRequest": {
                                 "url": {
@@ -4836,7 +4836,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4845,7 +4845,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4867,7 +4867,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -4893,12 +4893,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c5d7872b-2f38-47d2-8ec6-12511ec9b67d",
+                            "id": "5a273209-7499-4167-b2e9-250e871f3f38",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -4920,7 +4920,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -4929,7 +4929,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -4951,7 +4951,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5013,12 +5013,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d60fc741-85ee-4acc-8ab8-c5daacd68e2b",
+                            "id": "c728b39d-6f5b-4faf-aa3a-0596566acfc9",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5040,7 +5040,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "disabled": false,
@@ -5049,7 +5049,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "Idempotency-Key",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5071,7 +5071,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": 1385,\n        \"key_1\": 8539,\n        \"key_2\": \"string\"\n      },\n      \"output\": {\n        \"key_0\": false,\n        \"key_1\": 191.89643675053603\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": true,\n        \"key_1\": 3833\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"traces\": [\n    {\n      \"session_id\": \"<string>\",\n      \"type\": \"<string>\",\n      \"model\": \"<string>\",\n      \"provider\": \"<string>\",\n      \"input\": {\n        \"key_0\": true\n      },\n      \"output\": {\n        \"key_0\": 4899.833496846239\n      },\n      \"latency_ms\": \"<integer>\",\n      \"metadata\": {\n        \"key_0\": \"string\",\n        \"key_1\": \"string\"\n      },\n      \"timestamp\": \"<dateTime>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5097,7 +5097,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5114,7 +5114,7 @@
             "description": "Conversation records (used by the Python SDK and for batch imports).",
             "item": [
                 {
-                    "id": "82e038ab-5e80-4fa9-a75d-05cb67995f33",
+                    "id": "2ac3030b-1616-4a0f-91a7-ce998eaa55fe",
                     "name": "Upload conversation records (batch)",
                     "request": {
                         "name": "Upload conversation records (batch)",
@@ -5141,7 +5141,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -5155,7 +5155,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                            "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -5167,7 +5167,7 @@
                     },
                     "response": [
                         {
-                            "id": "bb035783-7b19-4c7a-85c2-0380dd842f38",
+                            "id": "84e4a272-0781-4d5f-91f0-b425de76ce5e",
                             "name": "Records processed",
                             "originalRequest": {
                                 "url": {
@@ -5189,7 +5189,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5211,7 +5211,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5264,12 +5264,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": 626.7520264454652,\n    \"key_1\": 3659\n  }\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"dropped_count\": \"<integer>\",\n  \"details\": {\n    \"key_0\": false\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "05029714-fad5-43f7-a6bf-6b7e4083ce68",
+                            "id": "0919b52d-08d9-4bbe-8550-f7db9441744e",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5291,7 +5291,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5313,7 +5313,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5339,12 +5339,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4e233f54-cc2f-4ae8-a2a1-7edc585f6448",
+                            "id": "0b5a7395-2c10-4857-b6b1-7d1ec0c62079",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5366,7 +5366,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5388,7 +5388,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5414,12 +5414,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "297c5f88-c799-40e7-b751-3d3b62aa3267",
+                            "id": "217e7a17-41b6-400d-bcb6-cdf9be872bcc",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -5441,7 +5441,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5463,7 +5463,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5489,12 +5489,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3c781db5-86b6-40ea-969e-3146471cf0f5",
+                            "id": "0aedf5c9-f781-405e-b002-da8743ea1740",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -5516,7 +5516,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5538,7 +5538,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5600,12 +5600,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "299e817d-5f61-4e6e-a9a4-35cada2a4cf5",
+                            "id": "c85080e2-609b-4af2-9014-56e676a66be7",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -5627,7 +5627,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5649,7 +5649,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 2091.002176260645\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 1643\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    }\n  ]\n}",
+                                    "raw": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4586,\n            \"key_1\": true\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 2746\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"whatsapp\"\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5675,7 +5675,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -5692,7 +5692,7 @@
             "description": "Operational log entries.",
             "item": [
                 {
-                    "id": "a31934d3-6fa0-481c-9567-cd837a0f7eba",
+                    "id": "93883dfc-74d1-48cd-9cb1-22ca1bfb9029",
                     "name": "Upload operational logs (batch)",
                     "request": {
                         "name": "Upload operational logs (batch)",
@@ -5719,7 +5719,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -5733,7 +5733,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                            "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -5745,7 +5745,7 @@
                     },
                     "response": [
                         {
-                            "id": "9762b4ea-94f7-4b6f-a3a8-4269b47eb991",
+                            "id": "0c552b9e-b643-48f3-924a-74b08439d3a5",
                             "name": "Logs processed",
                             "originalRequest": {
                                 "url": {
@@ -5767,7 +5767,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5789,7 +5789,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5842,12 +5842,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": false\n}",
+                            "body": "{\n  \"inserted_count\": \"<integer>\",\n  \"key_0\": \"string\",\n  \"key_1\": 2930.0647556679837\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b702091e-1b32-4a79-a02f-6a2337bdd2c3",
+                            "id": "bb23d7f3-78aa-4a25-ba71-5b5004efe0b9",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -5869,7 +5869,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5891,7 +5891,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5917,12 +5917,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a01a77d2-e1eb-4024-91b0-d46a7e3e4f64",
+                            "id": "47d9fc49-de02-4e2f-98c8-571ac28c159c",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -5944,7 +5944,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -5966,7 +5966,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -5992,12 +5992,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3eefc2b1-4a65-415c-a02d-664a897e2c78",
+                            "id": "036b559d-9f10-46ed-b53a-cbcb01e3bcd6",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -6019,7 +6019,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6041,7 +6041,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6067,12 +6067,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "768a1268-4da4-4da6-8bd1-6b57b5728d8f",
+                            "id": "c8c7c6c8-143a-4e0d-82ba-df544d4c2d8a",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -6094,7 +6094,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6116,7 +6116,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6178,12 +6178,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5bda742a-e481-4e41-9aaa-494d498edf15",
+                            "id": "b65a0417-7b0a-47a9-a986-20c9196e994d",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -6205,7 +6205,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6227,7 +6227,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true\n      }\n    }\n  ]\n}",
+                                    "raw": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"debug\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": true,\n        \"key_1\": \"string\"\n      }\n    }\n  ]\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6253,7 +6253,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -6270,7 +6270,7 @@
             "description": "Read records and logs.",
             "item": [
                 {
-                    "id": "58624125-f870-41bb-8fdf-5b3934711b51",
+                    "id": "9baeb0b3-330a-4c86-b854-1aa732203a4f",
                     "name": "Query conversation records",
                     "request": {
                         "name": "Query conversation records",
@@ -6293,7 +6293,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -6319,7 +6319,7 @@
                     },
                     "response": [
                         {
-                            "id": "b6eb062b-9e2f-41ca-9980-8133efb16a6a",
+                            "id": "dc26b121-7372-49d6-8882-2eccec33e14a",
                             "name": "Records matching the query",
                             "originalRequest": {
                                 "url": {
@@ -6340,7 +6340,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6415,12 +6415,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": true,\n            \"key_1\": \"string\"\n          },\n          {\n            \"key_0\": false,\n            \"key_1\": \"string\",\n            \"key_2\": true,\n            \"key_3\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 6802\n          },\n          {\n            \"key_0\": true\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"other\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": true,\n            \"key_2\": 3249,\n            \"key_3\": 1706.7389246163912\n          },\n          {\n            \"key_0\": 4933.684405157869,\n            \"key_1\": 7256.622034868965\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": 9018.76274952053,\n            \"key_2\": 9267\n          },\n          {\n            \"key_0\": 8055\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"email\"\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a4fe969b-d31f-42ca-a301-e9791b074b0d",
+                            "id": "ed49fcb1-b247-4c9f-9edd-5d07e31a9bda",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -6441,7 +6441,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6489,12 +6489,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "ce778f9f-84e6-4c0d-92d2-5d5812e94582",
+                            "id": "dbedaa31-e901-46a1-b781-98780f4aa974",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -6515,7 +6515,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6563,12 +6563,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "150dbeeb-bc45-4cab-991c-5a0081102961",
+                            "id": "beb8fdd9-e719-417a-b60d-c3fbe7e7dcaa",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -6589,7 +6589,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6637,12 +6637,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c1a9ffa5-7ccc-4a25-89ab-85ec81329752",
+                            "id": "1fa7c64c-db46-4154-ac67-1b8d8d7ffc30",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -6663,7 +6663,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6747,12 +6747,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7aa79756-6786-40ba-a0fe-46ffc433be4b",
+                            "id": "e825ddc9-03cf-478b-ae10-ee7f6a65d4fb",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -6773,7 +6773,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6821,7 +6821,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -6832,7 +6832,7 @@
                     }
                 },
                 {
-                    "id": "b72feaaf-eefe-4435-a0f0-6a56f569f28b",
+                    "id": "6b878180-909f-462b-ba31-9cbb14d38a97",
                     "name": "Query log entries",
                     "request": {
                         "name": "Query log entries",
@@ -6856,7 +6856,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -6870,7 +6870,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -6882,7 +6882,7 @@
                     },
                     "response": [
                         {
-                            "id": "3472de87-09bf-4aff-ac28-3be848e960d3",
+                            "id": "48367fef-5c00-45b0-98e6-cc9973ca67a5",
                             "name": "Logs matching the query",
                             "originalRequest": {
                                 "url": {
@@ -6904,7 +6904,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -6926,7 +6926,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -6979,12 +6979,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\"\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": false\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"info\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 7150.688890013217,\n        \"key_1\": true,\n        \"key_2\": \"string\",\n        \"key_3\": 5806.485399946986,\n        \"key_4\": \"string\"\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 2397\n      }\n    }\n  ],\n  \"count\": \"<integer>\"\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "0c03feb1-cb60-4ea0-b8fa-b1604de66e2a",
+                            "id": "e46537fb-0c94-430b-b318-0896e170f03d",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -7006,7 +7006,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7028,7 +7028,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -7054,12 +7054,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7505f1b4-1a6e-4f61-82c9-a27a7f790f28",
+                            "id": "ea45f113-77ed-4806-87c1-94b0ba246b11",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -7081,7 +7081,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7103,7 +7103,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -7129,12 +7129,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b20b9b7d-4017-4fbb-92ad-31e5b261f2a6",
+                            "id": "90bbd5e1-021d-471d-a778-919907d47eb7",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -7156,7 +7156,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7178,7 +7178,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -7204,12 +7204,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6b923262-514f-4644-9ff0-d61f9afe8fa4",
+                            "id": "5ed40854-951d-4a87-bdf8-4403199dc813",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -7231,7 +7231,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7253,7 +7253,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -7315,12 +7315,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5fbbb5ca-c742-43bb-9844-693b59f71e60",
+                            "id": "75c270a9-1dcf-48bb-9a02-f24ca7c16fcc",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -7342,7 +7342,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7364,7 +7364,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"limit\": 100,\n  \"offset\": 0\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -7390,7 +7390,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -7407,7 +7407,7 @@
             "description": "Bulk export with server-side pagination.",
             "item": [
                 {
-                    "id": "06dd8f21-51d0-4a0b-8d3a-16d7e73786d7",
+                    "id": "9206655f-ebe5-4c85-94c4-b7143e3993fc",
                     "name": "Export conversation records (JSON or CSV)",
                     "request": {
                         "name": "Export conversation records (JSON or CSV)",
@@ -7431,7 +7431,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -7457,7 +7457,7 @@
                     },
                     "response": [
                         {
-                            "id": "0632601c-206c-43f3-859d-a136d6dfc3d1",
+                            "id": "f667558d-3225-421d-b28e-6973ba703372",
                             "name": "Records exported",
                             "originalRequest": {
                                 "url": {
@@ -7479,7 +7479,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7554,12 +7554,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"tool\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false,\n            \"key_1\": false\n          },\n          {\n            \"key_0\": 1890,\n            \"key_1\": 5649\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"file_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"sms\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": 4103.822011778756\n          },\n          {\n            \"key_0\": true,\n            \"key_1\": 9521.835087665508\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"web_search_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"telegram\"\n    }\n  ]\n}",
+                            "body": "{\n  \"records\": [\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"assistant\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": false\n          },\n          {\n            \"key_0\": 7769,\n            \"key_1\": 9933\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"web\"\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"agent\": \"<string>\",\n      \"msg\": {\n        \"role\": \"system\",\n        \"content\": \"<string>\",\n        \"sender\": \"<string>\",\n        \"tool_calls\": [\n          {\n            \"key_0\": \"string\",\n            \"key_1\": 4042\n          },\n          {\n            \"key_0\": \"string\"\n          }\n        ],\n        \"tool_call_id\": \"<string>\",\n        \"tool_name\": \"<string>\",\n        \"is_internal_tool\": \"<boolean>\",\n        \"internal_tool_type\": \"code_interpreter_call\"\n      },\n      \"session_id\": \"<string>\",\n      \"input_tokens\": \"<integer>\",\n      \"output_tokens\": \"<integer>\",\n      \"process_tokens\": \"<integer>\",\n      \"memory_tokens\": \"<integer>\",\n      \"total_tokens\": \"<integer>\",\n      \"transfers\": [\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        },\n        {\n          \"from\": \"<string>\",\n          \"to\": \"<string>\",\n          \"reason\": \"<string>\",\n          \"timestamp\": \"<string>\"\n        }\n      ],\n      \"inserted_at\": \"<dateTime>\",\n      \"user_id\": \"<string>\",\n      \"user_whatsapp\": \"<string>\",\n      \"wam_id\": \"<string>\",\n      \"replied_whatsapp\": \"<string>\",\n      \"attachments\": [\n        \"\",\n        \"\"\n      ],\n      \"source\": \"<string>\",\n      \"model\": \"<string>\",\n      \"external_user_id\": \"<string>\",\n      \"external_user_name\": \"<string>\",\n      \"external_user_channel\": \"email\"\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "585dd6e3-05fa-442a-97ca-22de1c6c0047",
+                            "id": "13d323ab-7dba-4efd-a6d9-bfb2a8597aa9",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -7581,7 +7581,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7629,12 +7629,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a0424c8d-9631-425f-a362-69a3d3c4af45",
+                            "id": "2a141768-475b-4ede-91d5-16aaefdbb137",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -7656,7 +7656,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7704,12 +7704,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9b8b5be8-dfd1-415b-98a9-46b8f319ae2c",
+                            "id": "302a3a3b-4c41-4e88-bc14-d18e6957dbc6",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -7731,7 +7731,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7779,12 +7779,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5b3235d0-b00f-4615-a4b4-8515b8cb1d6b",
+                            "id": "c74847f6-9a55-4a70-a3cf-d55dc45b9303",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -7806,7 +7806,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7890,12 +7890,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "786d4cb0-09b4-4dd9-aa31-2424e1d4843d",
+                            "id": "7955dde0-e28d-4e4f-89c2-89a87bacb52a",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -7917,7 +7917,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -7965,7 +7965,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -7976,7 +7976,7 @@
                     }
                 },
                 {
-                    "id": "23e70276-8b36-47e1-9a7f-946864aad90d",
+                    "id": "dcad5f27-3715-425b-bb68-5e3d3023d9bc",
                     "name": "Export logs (JSON or CSV)",
                     "request": {
                         "name": "Export logs (JSON or CSV)",
@@ -8000,7 +8000,7 @@
                                     "type": "text/plain"
                                 },
                                 "key": "X-Request-ID",
-                                "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                             },
                             {
                                 "key": "Content-Type",
@@ -8014,7 +8014,7 @@
                         "method": "POST",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                            "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                             "options": {
                                 "raw": {
                                     "headerFamily": "json",
@@ -8026,7 +8026,7 @@
                     },
                     "response": [
                         {
-                            "id": "c5e82e1a-3c44-4607-91c9-00475a463d16",
+                            "id": "6ebd5d0a-ca76-4de8-9310-0961952ae8fc",
                             "name": "Logs exported",
                             "originalRequest": {
                                 "url": {
@@ -8048,7 +8048,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -8070,7 +8070,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -8123,12 +8123,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 2407.929988474907,\n        \"key_1\": \"string\",\n        \"key_2\": true\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": \"string\",\n        \"key_1\": true\n      }\n    }\n  ]\n}",
+                            "body": "{\n  \"logs\": [\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"error\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 4978.935405339115\n      }\n    },\n    {\n      \"namespace\": \"<string>\",\n      \"level\": \"warn\",\n      \"message\": \"<string>\",\n      \"timestamp\": \"<dateTime>\",\n      \"resource_id\": \"<string>\",\n      \"custom_object\": {\n        \"key_0\": 6153\n      }\n    }\n  ]\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fe1a5941-b0d4-4978-8cd4-7c76857c94f3",
+                            "id": "90a7713e-a7b2-4743-b520-d949fce4ee50",
                             "name": "Bad Request — required field missing or invalid payload",
                             "originalRequest": {
                                 "url": {
@@ -8150,7 +8150,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -8172,7 +8172,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -8198,12 +8198,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b83d6d2c-307b-48ea-87e2-8ed22d419515",
+                            "id": "8c514eb9-18b2-4407-92ae-77a328e49b90",
                             "name": "Unauthorized — invalid or missing tracer token",
                             "originalRequest": {
                                 "url": {
@@ -8225,7 +8225,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -8247,7 +8247,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -8273,12 +8273,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "81162572-fda0-4091-8e49-1ed21e9fc61f",
+                            "id": "62272660-6075-4092-8ee1-9631dd389b27",
                             "name": "Forbidden — token does not have access to the resource",
                             "originalRequest": {
                                 "url": {
@@ -8300,7 +8300,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -8322,7 +8322,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -8348,12 +8348,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "cf213da7-fd3e-44a1-99fc-3687b2c0bf5d",
+                            "id": "a0d31a34-cc8d-43a1-946e-5244cac6d6ff",
                             "name": "Per-token rate limit exceeded for the bucket the route belongs\nto. The error envelope carries `code: \"rate_limit_exceeded\"`.\nWait `Retry-After` seconds (or `RateLimit-Reset` — they're\nidentical here) and retry. Limits are per-token, per-minute,\nfixed window.",
                             "originalRequest": {
                                 "url": {
@@ -8375,7 +8375,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -8397,7 +8397,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -8459,12 +8459,12 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "78257d17-563f-4946-9632-ad600a529896",
+                            "id": "694d7f41-0116-409e-83d4-6b8b482fa309",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -8486,7 +8486,7 @@
                                             "type": "text/plain"
                                         },
                                         "key": "X-Request-ID",
-                                        "value": "S{\"?K~on>dQ]W-'hT1^}"
+                                        "value": "iaO@-`-(,7Y.m[LBBd6,aOjVF~40BQ\\#.[gfXmA,*{y`Aj\\e)e7o465Hdo*9%F_"
                                     },
                                     {
                                         "key": "Content-Type",
@@ -8508,7 +8508,7 @@
                                 "method": "POST",
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"warn\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
+                                    "raw": "{\n  \"namespace\": \"<string>\",\n  \"level\": \"info\",\n  \"resource_id\": \"<string>\",\n  \"start_date\": \"<dateTime>\",\n  \"end_date\": \"<dateTime>\",\n  \"format\": \"json\"\n}",
                                     "options": {
                                         "raw": {
                                             "headerFamily": "json",
@@ -8534,7 +8534,7 @@
                                     "value": ""
                                 }
                             ],
-                            "body": "{\n  \"error\": {\n    \"code\": \"invalid_payload\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
+                            "body": "{\n  \"error\": {\n    \"code\": \"token_inactive\",\n    \"message\": \"<string>\",\n    \"request_id\": \"<string>\"\n  }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         }
@@ -8561,11 +8561,11 @@
     "variable": [
         {
             "key": "baseUrl",
-            "value": "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1"
+            "value": "https://api.monkai.com.br/trace/v1"
         }
     ],
     "info": {
-        "_postman_id": "76dc2a44-17b9-46bd-be6e-e9e6a2bda677",
+        "_postman_id": "8156cb1d-4ab5-4132-94af-6adfbfd5e008",
         "name": "MonkAI Trace API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {

--- a/scripts/add_code_samples.py
+++ b/scripts/add_code_samples.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
 
-API_BASE = "https://api.monkai.ai/trace/v1"
+API_BASE = "https://api.monkai.com.br/trace/v1"
 LEGACY_BASE = (
     "https://lpvbvnqrozlwalnkvrgk.supabase.co/functions/v1/monkai-api/v1"
 )


### PR DESCRIPTION
Companion docs do que ja esta deployado em prod ([#29](https://github.com/BeMonkAI/monkai-trace/pull/29)). API custom domain LIVE em \`https://api.monkai.com.br/trace/v1\` via Vercel Edge proxy + TLS Let's Encrypt.

## O que muda
- **\`docs/openapi.yaml\`** servers reordenados — \`api.monkai.com.br\` e o primario; URLs diretas do Supabase ficam como fallback
- **42 x-codeSamples** (14 ops × 3 langs) regenerados com a URL nova
- **\`scripts/add_code_samples.py\`** API_BASE atualizado pra futuras regeneracoes
- **\`docs/postman_collection.json\`** regenerado
- **\`docs/API_CHANGELOG.md\`** entry \`[v1.5] — 2026-05-03\`. **Fase 2 marcada COMPLETA**, Unreleased declara roadmap inteiro shipped.

## Smoke
\`\`\`
$ curl -s https://api.monkai.com.br/trace/v1/health | jq
{ \"status\": \"ok\", \"service\": \"monkai-trace\", \"api_version\": \"v1\", \"timestamp\": \"2026-05-03T01:35:23.011Z\" }
\`\`\`

Cert Let's Encrypt valido ate 2026-08-01 (Vercel auto-renova).

Closes #11