### PR TITLE
feat(claude-code): auto-trace sessions via SessionEnd hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,30 @@ tracer.upload_all_projects()
 tracer.upload_project("~/.claude/projects/-Users-me-myproject/")
 ```
 
+#### Auto-trace every Claude Code session
+
+Register a one-time hook and every session is uploaded automatically when it
+ends — no manual command, visible in the MonkAI Hub Monitoring view:
+
+```bash
+pip install monkai-trace
+
+# Export your tracer token (from MyAgents in the Hub) in your shell profile:
+export MONKAI_TRACE_TOKEN="tk_your_token"
+export MONKAI_TRACE_NAMESPACE="claude-code"   # optional, this is the default
+
+# Register the SessionEnd hook in ~/.claude/settings.json (idempotent):
+monkai-trace install-hook
+```
+
+The hook runs `monkai-trace claude-hook`, which reads the session transcript
+path from Claude Code and uploads it. It never raises, so a trace failure can
+never break your Claude Code session. Remove it anytime with
+`monkai-trace uninstall-hook`.
+
+> The transcript is uploaded once, when the session ends (`SessionEnd`). If you
+> resume a session and end it again, it is re-uploaded in full.
+
 ### Cline Integration
 
 ```python
@@ -377,6 +401,15 @@ pytest tests/ -x -q
 - `openai-agents-python` (optional, for OpenAI Agents integration)
 
 ## Changelog
+
+### v0.6.0
+
+- **New: `monkai-trace` CLI** with a Claude Code auto-trace hook
+  - `monkai-trace install-hook` registers a `SessionEnd` hook in `~/.claude/settings.json` so every session uploads automatically
+  - `monkai-trace claude-hook` reads the hook payload from stdin and uploads (never raises — a trace failure can't break your session)
+  - `monkai-trace uninstall-hook`, `upload-session`, `upload-project` for manual control
+  - Config via `MONKAI_TRACE_TOKEN` / `MONKAI_TRACE_NAMESPACE` / `MONKAI_TRACE_BASE_URL`
+  - `ClaudeCodeTracer` and `run_hook` now exported from `monkai_trace.integrations`
 
 ### v0.3.0
 

--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",

--- a/monkai_trace/cli.py
+++ b/monkai_trace/cli.py
@@ -1,0 +1,204 @@
+"""Command-line interface for MonkAI Trace.
+
+Exposes the ``monkai-trace`` console entrypoint. The primary use case is the
+Claude Code ``SessionEnd`` hook, which auto-uploads conversation transcripts to
+MonkAI Trace so they appear in the MonkAI Hub.
+
+Subcommands:
+    monkai-trace claude-hook        Read a Claude Code hook payload from stdin
+                                    and upload the session (used by settings.json).
+    monkai-trace install-hook       Register the SessionEnd hook in
+                                    ~/.claude/settings.json (idempotent).
+    monkai-trace uninstall-hook     Remove the hook from ~/.claude/settings.json.
+    monkai-trace upload-session ... Manually upload a single session JSONL.
+    monkai-trace upload-project ... Manually upload all sessions in a project dir.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
+HOOK_COMMAND = "monkai-trace claude-hook"
+DEFAULT_EVENT = "SessionEnd"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="monkai-trace",
+        description="MonkAI Trace CLI — auto-trace Claude Code conversations.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser(
+        "claude-hook",
+        help="Read a Claude Code hook payload from stdin and upload the session.",
+    )
+
+    p_install = sub.add_parser(
+        "install-hook",
+        help="Register the SessionEnd hook in ~/.claude/settings.json.",
+    )
+    p_install.add_argument(
+        "--event",
+        default=DEFAULT_EVENT,
+        help=f"Hook event to register on (default: {DEFAULT_EVENT}).",
+    )
+
+    sub.add_parser(
+        "uninstall-hook",
+        help="Remove the MonkAI Trace hook from ~/.claude/settings.json.",
+    )
+
+    p_session = sub.add_parser("upload-session", help="Upload a single Claude Code session JSONL.")
+    p_session.add_argument("path", help="Path to the .jsonl session file.")
+
+    p_project = sub.add_parser("upload-project", help="Upload all sessions in a project directory.")
+    p_project.add_argument("path", help="Path to the project directory.")
+
+    return parser
+
+
+def _require_token() -> Optional[str]:
+    token = os.environ.get("MONKAI_TRACE_TOKEN")
+    if not token:
+        print(
+            "error: MONKAI_TRACE_TOKEN is not set. Export your tracer token "
+            "(tk_...) before uploading.",
+            file=sys.stderr,
+        )
+    return token
+
+
+def _make_tracer(token: str):
+    from .integrations.claude_code import DEFAULT_HOOK_BASE_URL, ClaudeCodeTracer
+
+    return ClaudeCodeTracer(
+        tracer_token=token,
+        namespace=os.environ.get("MONKAI_TRACE_NAMESPACE", "claude-code"),
+        base_url=os.environ.get("MONKAI_TRACE_BASE_URL", DEFAULT_HOOK_BASE_URL),
+    )
+
+
+def _cmd_claude_hook() -> int:
+    from .integrations.claude_code import run_hook
+
+    return run_hook()
+
+
+def _cmd_install_hook(event: str) -> int:
+    settings = _load_settings(CLAUDE_SETTINGS)
+    hooks = settings.setdefault("hooks", {})
+    event_hooks = hooks.setdefault(event, [])
+
+    if _hook_present(event_hooks):
+        print(f"MonkAI Trace hook already registered on {event}.")
+        return 0
+
+    event_hooks.append({"hooks": [{"type": "command", "command": HOOK_COMMAND}]})
+    _save_settings(CLAUDE_SETTINGS, settings)
+    print(f"Registered MonkAI Trace hook on {event} in {CLAUDE_SETTINGS}.")
+    print(
+        "Make sure MONKAI_TRACE_TOKEN is exported in your shell profile so the "
+        "hook can authenticate."
+    )
+    return 0
+
+
+def _cmd_uninstall_hook() -> int:
+    if not CLAUDE_SETTINGS.exists():
+        print("No ~/.claude/settings.json found; nothing to remove.")
+        return 0
+
+    settings = _load_settings(CLAUDE_SETTINGS)
+    hooks = settings.get("hooks", {})
+    removed = False
+    for event, event_hooks in list(hooks.items()):
+        kept = [h for h in event_hooks if not _is_monkai_hook(h)]
+        if len(kept) != len(event_hooks):
+            removed = True
+            if kept:
+                hooks[event] = kept
+            else:
+                del hooks[event]
+
+    if removed:
+        _save_settings(CLAUDE_SETTINGS, settings)
+        print("Removed MonkAI Trace hook from ~/.claude/settings.json.")
+    else:
+        print("MonkAI Trace hook was not registered; nothing to remove.")
+    return 0
+
+
+def _cmd_upload_session(path: str) -> int:
+    token = _require_token()
+    if not token:
+        return 1
+    result = _make_tracer(token).upload_session(path)
+    print(json.dumps(result, default=str))
+    return 0
+
+
+def _cmd_upload_project(path: str) -> int:
+    token = _require_token()
+    if not token:
+        return 1
+    result = _make_tracer(token).upload_project(path)
+    print(json.dumps(result, default=str))
+    return 0
+
+
+# --- settings.json helpers -------------------------------------------------
+
+
+def _load_settings(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8") or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"error: {path} is not valid JSON ({exc}); fix it before installing.")
+
+
+def _save_settings(path: Path, settings: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup = path.with_suffix(path.suffix + ".bak")
+        backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    path.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+
+
+def _is_monkai_hook(entry: dict) -> bool:
+    inner = entry.get("hooks", []) if isinstance(entry, dict) else []
+    return any(isinstance(h, dict) and h.get("command") == HOOK_COMMAND for h in inner)
+
+
+def _hook_present(event_hooks: List[dict]) -> bool:
+    return any(_is_monkai_hook(h) for h in event_hooks)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "claude-hook":
+        return _cmd_claude_hook()
+    if args.command == "install-hook":
+        return _cmd_install_hook(args.event)
+    if args.command == "uninstall-hook":
+        return _cmd_uninstall_hook()
+    if args.command == "upload-session":
+        return _cmd_upload_session(args.path)
+    if args.command == "upload-project":
+        return _cmd_upload_project(args.path)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/monkai_trace/integrations/__init__.py
+++ b/monkai_trace/integrations/__init__.py
@@ -5,6 +5,7 @@ from .logging import MonkAILogHandler
 from .langchain import MonkAICallbackHandler
 from .monkai_agent import MonkAIAgentHooks
 from .bot_framework import infer_channel
+from .claude_code import ClaudeCodeTracer, run_hook
 
 __all__ = [
     "MonkAIRunHooks",
@@ -12,4 +13,6 @@ __all__ = [
     "MonkAICallbackHandler",
     "MonkAIAgentHooks",
     "infer_channel",
+    "ClaudeCodeTracer",
+    "run_hook",
 ]

--- a/monkai_trace/integrations/claude_code.py
+++ b/monkai_trace/integrations/claude_code.py
@@ -34,7 +34,7 @@ Example:
 import json
 import logging
 import os
-from datetime import datetime
+import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -95,9 +95,7 @@ class ClaudeCodeTracer:
 
         if self.auto_upload:
             result = self.client.upload_records_batch(records)
-            logger.info(
-                f"Uploaded {result['total_inserted']} records from {path.name}"
-            )
+            logger.info(f"Uploaded {result['total_inserted']} records from {path.name}")
             return result
 
         self._records.extend(records)
@@ -180,12 +178,14 @@ class ClaudeCodeTracer:
             sessions = list(project_dir.glob("*.jsonl"))
             # Decode project path: -Users-me-project -> /Users/me/project
             decoded_path = "/" + project_dir.name.lstrip("-").replace("-", "/")
-            projects.append({
-                "encoded_name": project_dir.name,
-                "decoded_path": decoded_path,
-                "session_count": len(sessions),
-                "dir": str(project_dir),
-            })
+            projects.append(
+                {
+                    "encoded_name": project_dir.name,
+                    "decoded_path": decoded_path,
+                    "session_count": len(sessions),
+                    "dir": str(project_dir),
+                }
+            )
         return projects
 
     def flush(self) -> Dict:
@@ -220,11 +220,13 @@ class ClaudeCodeTracer:
             messages = []
 
             # User message
-            messages.append(Message(
-                role="user",
-                content=user_msg.get("content", ""),
-                sender="user",
-            ))
+            messages.append(
+                Message(
+                    role="user",
+                    content=user_msg.get("content", ""),
+                    sender="user",
+                )
+            )
 
             # Assistant messages (text, tool_use, etc.)
             for amsg in assistant_msgs:
@@ -240,11 +242,13 @@ class ClaudeCodeTracer:
                         if btype == "text":
                             text_parts.append(block.get("text", ""))
                         elif btype == "tool_use":
-                            tool_calls.append({
-                                "name": block.get("name", ""),
-                                "arguments": block.get("input", {}),
-                                "id": block.get("id", ""),
-                            })
+                            tool_calls.append(
+                                {
+                                    "name": block.get("name", ""),
+                                    "arguments": block.get("input", {}),
+                                    "id": block.get("id", ""),
+                                }
+                            )
                         # Skip thinking blocks
 
                 content = "\n".join(text_parts) if text_parts else None
@@ -260,13 +264,15 @@ class ClaudeCodeTracer:
 
                 # Add tool messages for each tool call
                 for tc in tool_calls:
-                    messages.append(Message(
-                        role="tool",
-                        content=f"Tool: {tc['name']}",
-                        sender=self.agent_name,
-                        tool_name=tc["name"],
-                        tool_calls=[tc],
-                    ))
+                    messages.append(
+                        Message(
+                            role="tool",
+                            content=f"Tool: {tc['name']}",
+                            sender=self.agent_name,
+                            tool_name=tc["name"],
+                            tool_calls=[tc],
+                        )
+                    )
 
             # Build token usage
             token_usage = TokenUsage.from_anthropic_usage(usage) if usage else TokenUsage()
@@ -291,14 +297,10 @@ class ClaudeCodeTracer:
             )
             records.append(record)
 
-        logger.info(
-            f"Parsed {len(records)} conversation turns from {path.name}"
-        )
+        logger.info(f"Parsed {len(records)} conversation turns from {path.name}")
         return records
 
-    def _group_turns(
-        self, lines: List[Dict]
-    ) -> List[Tuple[Dict, List[Dict], Dict]]:
+    def _group_turns(self, lines: List[Dict]) -> List[Tuple[Dict, List[Dict], Dict]]:
         """
         Group JSONL lines into conversation turns.
 
@@ -317,11 +319,13 @@ class ClaudeCodeTracer:
             if msg_type == "user":
                 # New turn starts
                 if current_user is not None and current_assistants:
-                    turns.append((
-                        current_user,
-                        current_assistants,
-                        current_usage,
-                    ))
+                    turns.append(
+                        (
+                            current_user,
+                            current_assistants,
+                            current_usage,
+                        )
+                    )
 
                 user_message = line.get("message", {})
                 content = user_message.get("content", "")
@@ -360,10 +364,12 @@ class ClaudeCodeTracer:
                                 break
 
                 if has_content:
-                    current_assistants.append({
-                        "content": content,
-                        "model": model,
-                    })
+                    current_assistants.append(
+                        {
+                            "content": content,
+                            "model": model,
+                        }
+                    )
 
         # Don't forget the last turn
         if current_user is not None and current_assistants:
@@ -401,3 +407,61 @@ class ClaudeCodeTracer:
         Example: '/Users/arthurvaz/Desktop' -> '-Users-arthurvaz-Desktop'
         """
         return path.replace("/", "-")
+
+
+# Default public base URL for the SessionEnd hook (Vercel proxy → Supabase).
+DEFAULT_HOOK_BASE_URL = "https://api.monkai.com.br/trace/v1"
+
+
+def run_hook(stdin=None) -> int:
+    """Entrypoint for the Claude Code ``SessionEnd`` hook.
+
+    Reads the hook payload as JSON from stdin (Claude Code provides
+    ``{session_id, transcript_path, cwd, reason, ...}``), then parses and
+    uploads the full session transcript to MonkAI Trace.
+
+    Configuration is resolved from environment variables so the hook can be
+    invoked with zero arguments:
+
+    - ``MONKAI_TRACE_TOKEN`` (required): tracer token (``tk_...``).
+    - ``MONKAI_TRACE_NAMESPACE`` (optional, default ``claude-code``).
+    - ``MONKAI_TRACE_BASE_URL`` (optional, default the public proxy).
+
+    This function NEVER raises: a hook that fails must not break the user's
+    Claude Code session. All failures are logged and swallowed, returning 0.
+
+    Returns:
+        Always 0 (success exit code for the hook runner).
+    """
+    try:
+        raw = (stdin or sys.stdin).read()
+        payload = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, ValueError, OSError) as exc:
+        logger.warning("Could not read Claude Code hook payload: %s", exc)
+        return 0
+
+    transcript = payload.get("transcript_path")
+    if not transcript:
+        logger.info("Hook payload has no transcript_path; nothing to upload")
+        return 0
+
+    token = os.environ.get("MONKAI_TRACE_TOKEN")
+    if not token:
+        logger.warning("MONKAI_TRACE_TOKEN not set; skipping Claude Code trace upload")
+        return 0
+
+    try:
+        tracer = ClaudeCodeTracer(
+            tracer_token=token,
+            namespace=os.environ.get("MONKAI_TRACE_NAMESPACE", "claude-code"),
+            base_url=os.environ.get("MONKAI_TRACE_BASE_URL", DEFAULT_HOOK_BASE_URL),
+        )
+        result = tracer.upload_session(transcript)
+        logger.info(
+            "Claude Code session uploaded: %s records inserted",
+            result.get("total_inserted", 0),
+        )
+    except Exception:  # noqa: BLE001 - hook must never crash the session
+        logger.exception("Failed to upload Claude Code session trace")
+
+    return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.5.0"
+version = "0.6.0"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -44,6 +44,9 @@ dev = [
     "mypy>=1.7.0",
     "types-requests>=2.31.0",
 ]
+
+[project.scripts]
+monkai-trace = "monkai_trace.cli:main"
 
 [project.urls]
 Homepage = "https://monkai.ai"

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -1,0 +1,174 @@
+"""Tests for the Claude Code integration: transcript parsing, the SessionEnd
+hook entrypoint, and settings.json hook install/uninstall."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from monkai_trace import cli
+from monkai_trace.client import MonkAIClient
+from monkai_trace.integrations.claude_code import ClaudeCodeTracer, run_hook
+
+
+def _write_jsonl(path: Path, lines: list) -> Path:
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    return path
+
+
+SAMPLE_SESSION = [
+    {"type": "user", "message": {"content": "List the files"}},
+    {
+        "type": "assistant",
+        "message": {
+            "model": "claude-opus-4",
+            "content": [
+                {"type": "text", "text": "Sure, listing now."},
+                {"type": "tool_use", "name": "Bash", "input": {"cmd": "ls"}, "id": "t1"},
+            ],
+            "usage": {"input_tokens": 12, "output_tokens": 8},
+        },
+    },
+]
+
+
+# --- parsing ---------------------------------------------------------------
+
+
+def test_parse_session_builds_records(tmp_path):
+    session = _write_jsonl(tmp_path / "abc123.jsonl", SAMPLE_SESSION)
+    tracer = ClaudeCodeTracer(tracer_token="tk_test", namespace="claude-code", auto_upload=False)
+
+    records = tracer._parse_session(session)
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.session_id == "abc123"
+    assert rec.namespace == "claude-code"
+    roles = [m.role for m in rec.msg]
+    assert roles == ["user", "assistant", "tool"]
+    assert rec.input_tokens == 12
+    assert rec.output_tokens == 8
+
+
+def test_parse_session_empty_file(tmp_path):
+    empty = _write_jsonl(tmp_path / "empty.jsonl", [])
+    tracer = ClaudeCodeTracer(tracer_token="tk_test", namespace="claude-code", auto_upload=False)
+    assert tracer._parse_session(empty) == []
+
+
+# --- run_hook --------------------------------------------------------------
+
+
+class _StdIn:
+    def __init__(self, text):
+        self._text = text
+
+    def read(self):
+        return self._text
+
+
+def test_run_hook_uploads_session(tmp_path, monkeypatch):
+    session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN", "tk_test")
+
+    mock_client = Mock(spec=MonkAIClient)
+    mock_client.upload_records_batch.return_value = {
+        "total_inserted": 1,
+        "total_records": 1,
+        "failures": [],
+    }
+    monkeypatch.setattr(
+        "monkai_trace.integrations.claude_code.MonkAIClient",
+        lambda *a, **k: mock_client,
+    )
+
+    payload = json.dumps({"transcript_path": str(session), "session_id": "sess"})
+    assert run_hook(stdin=_StdIn(payload)) == 0
+    mock_client.upload_records_batch.assert_called_once()
+
+
+def test_run_hook_without_token_skips_upload(tmp_path, monkeypatch):
+    session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
+    monkeypatch.delenv("MONKAI_TRACE_TOKEN", raising=False)
+
+    # If a tracer were built, this would explode — proving no upload happens.
+    monkeypatch.setattr(
+        "monkai_trace.integrations.claude_code.ClaudeCodeTracer",
+        Mock(side_effect=AssertionError("tracer must not be built without token")),
+    )
+
+    payload = json.dumps({"transcript_path": str(session)})
+    assert run_hook(stdin=_StdIn(payload)) == 0
+
+
+def test_run_hook_no_transcript_path():
+    assert run_hook(stdin=_StdIn(json.dumps({"session_id": "x"}))) == 0
+
+
+def test_run_hook_invalid_json_does_not_raise():
+    assert run_hook(stdin=_StdIn("not-json{{")) == 0
+
+
+def test_run_hook_upload_failure_is_swallowed(tmp_path, monkeypatch):
+    session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN", "tk_test")
+    mock_client = Mock(spec=MonkAIClient)
+    mock_client.upload_records_batch.side_effect = RuntimeError("network down")
+    monkeypatch.setattr(
+        "monkai_trace.integrations.claude_code.MonkAIClient",
+        lambda *a, **k: mock_client,
+    )
+    payload = json.dumps({"transcript_path": str(session)})
+    assert run_hook(stdin=_StdIn(payload)) == 0  # never propagates
+
+
+# --- install/uninstall hook ------------------------------------------------
+
+
+@pytest.fixture
+def fake_settings(tmp_path, monkeypatch):
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(cli, "CLAUDE_SETTINGS", settings_path)
+    return settings_path
+
+
+def test_install_hook_is_idempotent(fake_settings):
+    assert cli.main(["install-hook"]) == 0
+    assert cli.main(["install-hook"]) == 0  # second time = no-op
+
+    data = json.loads(fake_settings.read_text())
+    session_end = data["hooks"]["SessionEnd"]
+    monkai_entries = [
+        h
+        for h in session_end
+        if any(i.get("command") == cli.HOOK_COMMAND for i in h.get("hooks", []))
+    ]
+    assert len(monkai_entries) == 1
+
+
+def test_install_hook_preserves_existing_hooks(fake_settings):
+    fake_settings.write_text(
+        json.dumps(
+            {"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": "other"}]}]}}
+        )
+    )
+    assert cli.main(["install-hook"]) == 0
+
+    session_end = json.loads(fake_settings.read_text())["hooks"]["SessionEnd"]
+    commands = [i["command"] for h in session_end for i in h["hooks"]]
+    assert "other" in commands
+    assert cli.HOOK_COMMAND in commands
+
+
+def test_uninstall_hook_removes_only_monkai(fake_settings):
+    cli.main(["install-hook"])
+    assert cli.main(["uninstall-hook"]) == 0
+    data = json.loads(fake_settings.read_text())
+    assert "SessionEnd" not in data.get("hooks", {})
+
+
+def test_uninstall_hook_no_settings(fake_settings):
+    assert not fake_settings.exists()
+    assert cli.main(["uninstall-hook"]) == 0


### PR DESCRIPTION
## O que foi feito
- Novo CLI `monkai-trace` (`[project.scripts]`) com subcomandos:
  - `install-hook` / `uninstall-hook` — registra/remove o hook `SessionEnd` em `~/.claude/settings.json` (idempotente, faz backup `.bak`, preserva hooks existentes)
  - `claude-hook` — le o payload do hook via stdin e sobe o transcript (chamado pelo settings.json)
  - `upload-session` / `upload-project` — uso manual
- `run_hook()` em `claude_code.py` — **nunca levanta excecao** (hook que falha nao pode travar a sessao do Claude Code); resolve config por env (`MONKAI_TRACE_TOKEN`, `MONKAI_TRACE_NAMESPACE`, `MONKAI_TRACE_BASE_URL` → default proxy `api.monkai.com.br/trace/v1`)
- Export de `ClaudeCodeTracer` e `run_hook` em `integrations/__init__.py`
- Removido import morto (`datetime`) em claude_code.py (5S)
- Bump `0.5.0` → `0.6.0` + changelog + secao no README

## Por que
O `ClaudeCodeTracer` ja parseava/subia transcripts, mas exigia rodar na mao. Este PR fecha o fluxo zero-touch: 1x `install-hook` e toda conversa sobe sozinha ao encerrar a sessao, visivel no Monitoring do Hub. **Zero mudanca no monkai-hub** — a ingestao e a renderizacao por namespace ja existem.

## Como testar
1. `pip install -e . && pytest tests/test_claude_code.py -v` (11 testes)
2. `export MONKAI_TRACE_TOKEN=tk_... && monkai-trace install-hook` → confere bloco em ~/.claude/settings.json
3. Encerrar uma sessao do Claude Code → record aparece no Hub Monitoring (namespace `claude-code`)

## Limitacao conhecida (Opcao A)
Sessao retomada e re-encerrada → re-upload integral (sem dedup no `/records/upload`). Evolucao para upload incremental (Opcao B) fica como issue de follow-up.

## Checklist
- [x] Testes passando (11 novos; falhas restantes na suite sao deps opcionais faltando, pre-existentes)
- [x] black + ruff limpos nos arquivos tocados
- [x] Build / entrypoint smoke (`monkai-trace --help`)
- [x] Lib agnostica de cliente (sem nomes de cliente no diff)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)