### PR TITLE
fix(anonymizer): redact PII in tool_calls + quiet content=None

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,11 @@ pytest tests/ -x -q
 
 ## Changelog
 
+### v0.6.1
+
+- **Security: redact PII inside `tool_calls`** — tool-call `arguments` (file paths, emails, free-text) are now anonymized by the baseline anonymizer. Previously the `tool_calls` field bypassed redaction entirely.
+- Messages with `content: null` (tool-only assistant turns, tool messages) no longer emit a spurious "PII may be transmitted unredacted" warning; the warning is reserved for genuinely unexpected content types.
+
 ### v0.6.0
 
 - **New: `monkai-trace` CLI** with a Claude Code auto-trace hook

--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",

--- a/monkai_trace/anonymizer/baseline.py
+++ b/monkai_trace/anonymizer/baseline.py
@@ -89,9 +89,7 @@ BASELINE_RULES: List[BaselineRule] = [
     ),
     BaselineRule(
         name="ipv6",
-        pattern=re.compile(
-            r"\b[0-9a-fA-F]{1,4}(?::{1,2}[0-9a-fA-F]{1,4}){2,7}\b"
-        ),
+        pattern=re.compile(r"\b[0-9a-fA-F]{1,4}(?::{1,2}[0-9a-fA-F]{1,4}){2,7}\b"),
         replacement="[IP]",
     ),
     BaselineRule(
@@ -168,21 +166,36 @@ class BaselineAnonymizer:
             messages = [messages]
         out: List[Any] = []
         for msg in messages:
-            if not isinstance(msg, dict) or "content" not in msg:
+            if not isinstance(msg, dict):
                 out.append(msg)
                 continue
-            content = msg["content"]
             new_msg = dict(msg)
-            if isinstance(content, str):
-                new_msg["content"] = self.apply(content, disabled)
-            elif isinstance(content, list):
-                new_msg["content"] = [self._anonymize_block(b, disabled) for b in content]
-            else:
-                logger.warning(
-                    "BaselineAnonymizer: skipping message with unsupported content "
-                    "type %s; PII may be transmitted unredacted",
-                    type(content).__name__,
-                )
+            if "content" in msg:
+                content = msg["content"]
+                if isinstance(content, str):
+                    new_msg["content"] = self.apply(content, disabled)
+                elif isinstance(content, list):
+                    new_msg["content"] = [self._anonymize_block(b, disabled) for b in content]
+                elif content is None:
+                    # Legitimate for tool-only assistant turns / tool messages.
+                    # Nothing to redact in ``content`` itself; ``tool_calls`` is
+                    # handled below.
+                    pass
+                else:
+                    logger.warning(
+                        "BaselineAnonymizer: skipping message with unsupported "
+                        "content type %s; PII may be transmitted unredacted",
+                        type(content).__name__,
+                    )
+            # Tool call arguments are structured content that can carry PII
+            # (file paths, emails, free-text args) and live in a separate field,
+            # so they must be redacted regardless of the ``content`` shape.
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list):
+                new_msg["tool_calls"] = [
+                    self._anonymize_dict(tc, disabled) if isinstance(tc, dict) else tc
+                    for tc in tool_calls
+                ]
             out.append(new_msg)
         return out
 
@@ -214,9 +227,13 @@ class BaselineAnonymizer:
                 out[k] = self._anonymize_dict(v, disabled)
             elif isinstance(v, list):
                 out[k] = [
-                    self.apply(item, disabled) if isinstance(item, str)
-                    else self._anonymize_dict(item, disabled) if isinstance(item, dict)
-                    else item
+                    (
+                        self.apply(item, disabled)
+                        if isinstance(item, str)
+                        else (
+                            self._anonymize_dict(item, disabled) if isinstance(item, dict) else item
+                        )
+                    )
                     for item in v
                 ]
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.6.0"
+version = "0.6.1"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_baseline_anonymizer.py
+++ b/tests/test_baseline_anonymizer.py
@@ -20,10 +20,13 @@ def test_apply_returns_string_for_string_input():
     assert result == "hello world"
 
 
-@pytest.mark.parametrize("text, expected_redacted", [
-    ("CPF 123.456.789-09 do cliente", "CPF [CPF] do cliente"),
-    ("12345678909 sem mascara", "[CPF] sem mascara"),
-])
+@pytest.mark.parametrize(
+    "text, expected_redacted",
+    [
+        ("CPF 123.456.789-09 do cliente", "CPF [CPF] do cliente"),
+        ("12345678909 sem mascara", "[CPF] sem mascara"),
+    ],
+)
 def test_redacts_cpf(text, expected_redacted):
     assert BaselineAnonymizer().apply(text) == expected_redacted
 
@@ -32,27 +35,36 @@ def test_does_not_redact_invalid_cpf_length():
     assert BaselineAnonymizer().apply("number 1234") == "number 1234"
 
 
-@pytest.mark.parametrize("text, expected_redacted", [
-    ("CNPJ 12.345.678/0001-95", "CNPJ [CNPJ]"),
-    ("12345678000195 raw", "[CNPJ] raw"),
-])
+@pytest.mark.parametrize(
+    "text, expected_redacted",
+    [
+        ("CNPJ 12.345.678/0001-95", "CNPJ [CNPJ]"),
+        ("12345678000195 raw", "[CNPJ] raw"),
+    ],
+)
 def test_redacts_cnpj(text, expected_redacted):
     assert BaselineAnonymizer().apply(text) == expected_redacted
 
 
-@pytest.mark.parametrize("text, expected_redacted", [
-    ("contact arthur@monkai.com.br please", "contact [EMAIL] please"),
-    ("first.last+tag@sub.example.io", "[EMAIL]"),
-])
+@pytest.mark.parametrize(
+    "text, expected_redacted",
+    [
+        ("contact arthur@monkai.com.br please", "contact [EMAIL] please"),
+        ("first.last+tag@sub.example.io", "[EMAIL]"),
+    ],
+)
 def test_redacts_email(text, expected_redacted):
     assert BaselineAnonymizer().apply(text) == expected_redacted
 
 
-@pytest.mark.parametrize("text, expected_redacted", [
-    ("call (11) 99999-1234 today", "call [PHONE] today"),
-    ("+55 11 9 9999-1234", "[PHONE]"),
-    ("11999991234", "[PHONE]"),
-])
+@pytest.mark.parametrize(
+    "text, expected_redacted",
+    [
+        ("call (11) 99999-1234 today", "call [PHONE] today"),
+        ("+55 11 9 9999-1234", "[PHONE]"),
+        ("11999991234", "[PHONE]"),
+    ],
+)
 def test_redacts_brazilian_phone(text, expected_redacted):
     assert BaselineAnonymizer().apply(text) == expected_redacted
 
@@ -67,17 +79,23 @@ def test_does_not_redact_non_luhn_card_number():
     assert BaselineAnonymizer().apply("4111 1111 1111 1112") == "4111 1111 1111 1112"
 
 
-@pytest.mark.parametrize("text, expected_redacted", [
-    ("server 192.168.1.1 down", "server [IP] down"),
-    ("ipv6 2001:0db8:85a3::8a2e:0370:7334", "ipv6 [IP]"),
-])
+@pytest.mark.parametrize(
+    "text, expected_redacted",
+    [
+        ("server 192.168.1.1 down", "server [IP] down"),
+        ("ipv6 2001:0db8:85a3::8a2e:0370:7334", "ipv6 [IP]"),
+    ],
+)
 def test_redacts_ip(text, expected_redacted):
     assert BaselineAnonymizer().apply(text) == expected_redacted
 
 
-@pytest.mark.parametrize("text, expected_redacted", [
-    ("RG 12.345.678-9", "RG [RG]"),
-])
+@pytest.mark.parametrize(
+    "text, expected_redacted",
+    [
+        ("RG 12.345.678-9", "RG [RG]"),
+    ],
+)
 def test_redacts_rg(text, expected_redacted):
     assert BaselineAnonymizer().apply(text) == expected_redacted
 
@@ -97,21 +115,27 @@ def test_pipeline_order_cpf_before_card():
     assert BaselineAnonymizer().apply(text) == expected
 
 
-@pytest.mark.parametrize("digits, expected", [
-    ("12345678909", True),    # canonical Receita example, valid
-    ("11111111111", False),   # all-same-digit rejected
-    ("12345678900", False),   # wrong second check digit
-    ("123", False),           # too short
-])
+@pytest.mark.parametrize(
+    "digits, expected",
+    [
+        ("12345678909", True),  # canonical Receita example, valid
+        ("11111111111", False),  # all-same-digit rejected
+        ("12345678900", False),  # wrong second check digit
+        ("123", False),  # too short
+    ],
+)
 def test_cpf_check_digits_valid(digits, expected):
     assert _cpf_check_digits_valid(digits) is expected
 
 
-@pytest.mark.parametrize("digits, expected", [
-    ("4111111111111111", True),
-    ("4111111111111112", False),
-    ("123", False),
-])
+@pytest.mark.parametrize(
+    "digits, expected",
+    [
+        ("4111111111111111", True),
+        ("4111111111111112", False),
+        ("123", False),
+    ],
+)
 def test_luhn_valid(digits, expected):
     assert _luhn_valid(digits) is expected
 
@@ -228,3 +252,51 @@ def test_apply_to_messages_does_not_mutate_input():
     a.apply_to_messages([original])
     # input untouched
     assert original["content"][0]["text"] == "CPF 123.456.789-09"
+
+
+# ---------------------------------------------------------------------------
+# tool_calls field — flattened structured content (e.g. Claude Code, OpenAI)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_to_messages_redacts_tool_calls_arguments():
+    a = BaselineAnonymizer()
+    msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "name": "send_email",
+                "arguments": {"to": "arthur@monkai.com.br", "cpf": "12345678909"},
+                "id": "call_1",
+            }
+        ],
+    }
+    out = a.apply_to_messages([msg])
+    tc = out[0]["tool_calls"][0]
+    assert tc["arguments"]["to"] == "[EMAIL]"
+    assert tc["arguments"]["cpf"] == "[CPF]"
+    # non-PII fields preserved
+    assert tc["name"] == "send_email"
+    assert tc["id"] == "call_1"
+    assert out[0]["content"] is None
+
+
+def test_apply_to_messages_redacts_tool_calls_with_string_content():
+    a = BaselineAnonymizer()
+    msg = {
+        "role": "assistant",
+        "content": "ligando para o cliente",
+        "tool_calls": [{"name": "lookup", "arguments": {"q": "CPF 123.456.789-09"}}],
+    }
+    out = a.apply_to_messages([msg])
+    assert out[0]["content"] == "ligando para o cliente"
+    assert out[0]["tool_calls"][0]["arguments"]["q"] == "CPF [CPF]"
+
+
+def test_apply_to_messages_content_none_emits_no_warning(caplog):
+    a = BaselineAnonymizer()
+    with caplog.at_level("WARNING"):
+        out = a.apply_to_messages([{"role": "tool", "content": None}])
+    assert out == [{"role": "tool", "content": None}]
+    assert "PII may be transmitted unredacted" not in caplog.text


### PR DESCRIPTION
## O que foi feito
- `BaselineAnonymizer.apply_to_messages` agora anonimiza o campo `tool_calls` de cada mensagem (cada tool-call passa por `_anonymize_dict` recursivo). Antes, só `content` era inspecionado — argumentos de tool-call (paths, emails, texto livre) iam **sem redação**.
- Mensagens com `content=None` (turnos assistant só-tool_use, mensagens tool) não emitem mais o warning "PII may be transmitted unredacted"; o warning fica reservado para tipos de conteúdo realmente inesperados.
- Bump 0.6.0 → 0.6.1 + changelog.

## Por que
Achado no smoke do auto-trace Claude Code (#35): o warning disparava em massa e, mais grave, `tool_calls.arguments` (onde mora PII real) nunca era redado.

## Como testar
`pytest tests/test_baseline_anonymizer.py -v` — novos testes:
- `tool_calls.arguments` com email/CPF → redados; `name`/`id` preservados
- `content=None` → sem warning
- tipo inesperado (int) → ainda avisa

## Checklist
- [x] 69 testes verdes nos módulos afetados
- [x] black + ruff limpos
- [x] Lib agnóstica de cliente

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)