### PR TITLE
feat(claude-code): incremental upload + robust install-hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,13 @@ pytest tests/ -x -q
 
 ## Changelog
 
+### v0.7.0
+
+- **Incremental upload (per-session offsets)** — `ClaudeCodeTracer.upload_session_incremental()` uploads only the turns not sent before, persisting an offset per `session_id` under `~/.monkai_trace/` (override with `MONKAI_TRACE_STATE_DIR`). The hook now uses it, so a session can fire on every Claude Code `Stop` (near-realtime) without duplicating, and resumed `SessionEnd` is safe too.
+- **`monkai-trace install-hook` is robust** — registers an absolute, resolvable command (`shutil.which` / `python -m monkai_trace.cli`) so the hook runs even when `monkai-trace` is not on the hook runner's PATH. New `--token-file` (bakes `MONKAI_TRACE_TOKEN_FILE`) and `--event Stop`; warns at install if no token is resolvable yet.
+- **Token from file** — `resolve_token()` falls back to `MONKAI_TRACE_TOKEN_FILE` (default `~/.monkai_trace_token`) when `MONKAI_TRACE_TOKEN` is unset, so the hook does not depend on the shell profile being sourced.
+- **`monkai-trace watch <dir>` / `ClaudeCodeTracer.watch()`** — poll a project directory and upload incrementally, for environments without a hook.
+
 ### v0.6.1
 
 - **Security: redact PII inside `tool_calls`** — tool-call `arguments` (file paths, emails, free-text) are now anonymized by the baseline anonymizer. Previously the `tool_calls` field bypassed redaction entirely.

--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",

--- a/monkai_trace/cli.py
+++ b/monkai_trace/cli.py
@@ -1,15 +1,16 @@
 """Command-line interface for MonkAI Trace.
 
 Exposes the ``monkai-trace`` console entrypoint. The primary use case is the
-Claude Code ``SessionEnd`` hook, which auto-uploads conversation transcripts to
-MonkAI Trace so they appear in the MonkAI Hub.
+Claude Code hook, which auto-uploads conversation transcripts to MonkAI Trace
+so they appear in the MonkAI Hub.
 
 Subcommands:
     monkai-trace claude-hook        Read a Claude Code hook payload from stdin
-                                    and upload the session (used by settings.json).
-    monkai-trace install-hook       Register the SessionEnd hook in
-                                    ~/.claude/settings.json (idempotent).
+                                    and incrementally upload the session.
+    monkai-trace install-hook       Register the hook in ~/.claude/settings.json
+                                    (idempotent; resolves an absolute command).
     monkai-trace uninstall-hook     Remove the hook from ~/.claude/settings.json.
+    monkai-trace watch <dir>        Poll a project dir and upload incrementally.
     monkai-trace upload-session ... Manually upload a single session JSONL.
     monkai-trace upload-project ... Manually upload all sessions in a project dir.
 """
@@ -18,6 +19,7 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import List, Optional
@@ -25,7 +27,9 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
-HOOK_COMMAND = "monkai-trace claude-hook"
+# Stable marker used to detect a MonkAI Trace hook regardless of how the
+# command path is resolved (bare name, absolute path, or `python -m`).
+HOOK_MARKER = "claude-hook"
 DEFAULT_EVENT = "SessionEnd"
 
 
@@ -43,17 +47,32 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_install = sub.add_parser(
         "install-hook",
-        help="Register the SessionEnd hook in ~/.claude/settings.json.",
+        help="Register the Claude Code hook in ~/.claude/settings.json.",
     )
     p_install.add_argument(
         "--event",
         default=DEFAULT_EVENT,
-        help=f"Hook event to register on (default: {DEFAULT_EVENT}).",
+        help=f"Hook event to register on (default: {DEFAULT_EVENT}). "
+        "Use 'Stop' for near-realtime per-turn uploads.",
+    )
+    p_install.add_argument(
+        "--token-file",
+        default=None,
+        help="Path to a file holding the tracer token (tk_...). Baked into the "
+        "hook command via MONKAI_TRACE_TOKEN_FILE; default ~/.monkai_trace_token.",
     )
 
     sub.add_parser(
         "uninstall-hook",
         help="Remove the MonkAI Trace hook from ~/.claude/settings.json.",
+    )
+
+    p_watch = sub.add_parser(
+        "watch", help="Poll a project directory and upload sessions incrementally."
+    )
+    p_watch.add_argument("path", help="Path to the project directory to watch.")
+    p_watch.add_argument(
+        "--interval", type=float, default=5.0, help="Seconds between scans (default 5)."
     )
 
     p_session = sub.add_parser("upload-session", help="Upload a single Claude Code session JSONL.")
@@ -66,11 +85,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _require_token() -> Optional[str]:
-    token = os.environ.get("MONKAI_TRACE_TOKEN")
+    from .integrations.claude_code import resolve_token
+
+    token = resolve_token()
     if not token:
         print(
-            "error: MONKAI_TRACE_TOKEN is not set. Export your tracer token "
-            "(tk_...) before uploading.",
+            "error: no tracer token found. Set MONKAI_TRACE_TOKEN or put it in "
+            "~/.monkai_trace_token (or MONKAI_TRACE_TOKEN_FILE).",
             file=sys.stderr,
         )
     return token
@@ -86,13 +107,33 @@ def _make_tracer(token: str):
     )
 
 
+def _resolve_hook_command(token_file: Optional[str]) -> str:
+    """Build a hook command that resolves regardless of the hook runner's PATH.
+
+    Prefers the absolute path of the installed ``monkai-trace`` binary; falls
+    back to ``<python> -m monkai_trace.cli`` when the binary is not on PATH.
+    When ``token_file`` is given, bakes ``MONKAI_TRACE_TOKEN_FILE`` into the
+    command so the token does not depend on the shell profile being sourced.
+    """
+    binary = shutil.which("monkai-trace")
+    if binary:
+        cmd = f"{binary} {HOOK_MARKER}"
+    else:
+        cmd = f"{sys.executable} -m monkai_trace.cli {HOOK_MARKER}"
+    if token_file:
+        cmd = f'MONKAI_TRACE_TOKEN_FILE="{token_file}" {cmd}'
+    return cmd
+
+
 def _cmd_claude_hook() -> int:
     from .integrations.claude_code import run_hook
 
     return run_hook()
 
 
-def _cmd_install_hook(event: str) -> int:
+def _cmd_install_hook(event: str, token_file: Optional[str]) -> int:
+    from .integrations.claude_code import resolve_token
+
     settings = _load_settings(CLAUDE_SETTINGS)
     hooks = settings.setdefault("hooks", {})
     event_hooks = hooks.setdefault(event, [])
@@ -101,13 +142,20 @@ def _cmd_install_hook(event: str) -> int:
         print(f"MonkAI Trace hook already registered on {event}.")
         return 0
 
-    event_hooks.append({"hooks": [{"type": "command", "command": HOOK_COMMAND}]})
+    command = _resolve_hook_command(token_file)
+    event_hooks.append({"hooks": [{"type": "command", "command": command}]})
     _save_settings(CLAUDE_SETTINGS, settings)
     print(f"Registered MonkAI Trace hook on {event} in {CLAUDE_SETTINGS}.")
-    print(
-        "Make sure MONKAI_TRACE_TOKEN is exported in your shell profile so the "
-        "hook can authenticate."
-    )
+    print(f"  command: {command}")
+
+    # Robustness: warn now if the hook would have no token at fire time.
+    if token_file is None and not resolve_token():
+        print(
+            "warning: no tracer token found yet. Export MONKAI_TRACE_TOKEN in "
+            "your shell profile, write it to ~/.monkai_trace_token, or re-run "
+            "with --token-file <path>.",
+            file=sys.stderr,
+        )
     return 0
 
 
@@ -133,6 +181,16 @@ def _cmd_uninstall_hook() -> int:
         print("Removed MonkAI Trace hook from ~/.claude/settings.json.")
     else:
         print("MonkAI Trace hook was not registered; nothing to remove.")
+    return 0
+
+
+def _cmd_watch(path: str, interval: float) -> int:
+    token = _require_token()
+    if not token:
+        return 1
+    print(f"Watching {path} every {interval}s (Ctrl-C to stop)...")
+    result = _make_tracer(token).watch(path, interval=interval)
+    print(json.dumps(result, default=str))
     return 0
 
 
@@ -176,7 +234,10 @@ def _save_settings(path: Path, settings: dict) -> None:
 
 def _is_monkai_hook(entry: dict) -> bool:
     inner = entry.get("hooks", []) if isinstance(entry, dict) else []
-    return any(isinstance(h, dict) and h.get("command") == HOOK_COMMAND for h in inner)
+    return any(
+        isinstance(h, dict) and isinstance(h.get("command"), str) and HOOK_MARKER in h["command"]
+        for h in inner
+    )
 
 
 def _hook_present(event_hooks: List[dict]) -> bool:
@@ -190,9 +251,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     if args.command == "claude-hook":
         return _cmd_claude_hook()
     if args.command == "install-hook":
-        return _cmd_install_hook(args.event)
+        return _cmd_install_hook(args.event, args.token_file)
     if args.command == "uninstall-hook":
         return _cmd_uninstall_hook()
+    if args.command == "watch":
+        return _cmd_watch(args.path, args.interval)
     if args.command == "upload-session":
         return _cmd_upload_session(args.path)
     if args.command == "upload-project":

--- a/monkai_trace/integrations/__init__.py
+++ b/monkai_trace/integrations/__init__.py
@@ -5,7 +5,7 @@ from .logging import MonkAILogHandler
 from .langchain import MonkAICallbackHandler
 from .monkai_agent import MonkAIAgentHooks
 from .bot_framework import infer_channel
-from .claude_code import ClaudeCodeTracer, run_hook
+from .claude_code import ClaudeCodeTracer, resolve_token, run_hook
 
 __all__ = [
     "MonkAIRunHooks",
@@ -15,4 +15,5 @@ __all__ = [
     "infer_channel",
     "ClaudeCodeTracer",
     "run_hook",
+    "resolve_token",
 ]

--- a/monkai_trace/integrations/claude_code.py
+++ b/monkai_trace/integrations/claude_code.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -100,6 +101,108 @@ class ClaudeCodeTracer:
 
         self._records.extend(records)
         return {"total_inserted": 0, "total_records": len(records), "failures": []}
+
+    def upload_session_incremental(self, session_path: str) -> Dict:
+        """Parse a session and upload only the turns not uploaded before.
+
+        Uses a per-``session_id`` offset persisted on disk (see
+        :func:`_load_offsets`) so the same growing transcript can be uploaded
+        repeatedly — e.g. on every Claude Code ``Stop`` event — without
+        duplicating turns. Also makes ``SessionEnd`` safe to re-fire (resumed
+        sessions no longer re-upload in full).
+
+        Args:
+            session_path: Path to the .jsonl session file.
+
+        Returns:
+            Upload result dict with counts (``skipped`` = turns already sent).
+        """
+        path = Path(session_path).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(f"Session file not found: {path}")
+
+        records = self._parse_session(path)
+        session_id = path.stem
+        already = _load_offsets().get(session_id, 0)
+        new_records = records[already:]
+
+        if not new_records:
+            logger.info(
+                "No new turns in %s (offset=%d, total=%d)",
+                path.name,
+                already,
+                len(records),
+            )
+            return {
+                "total_inserted": 0,
+                "total_records": 0,
+                "failures": [],
+                "skipped": already,
+            }
+
+        if self.auto_upload:
+            result = self.client.upload_records_batch(new_records)
+            _save_offset(session_id, len(records))
+            logger.info(
+                "Uploaded %s new turns from %s (was %d, now %d)",
+                result.get("total_inserted", 0),
+                path.name,
+                already,
+                len(records),
+            )
+            result["skipped"] = already
+            return result
+
+        self._records.extend(new_records)
+        return {
+            "total_inserted": 0,
+            "total_records": len(new_records),
+            "failures": [],
+            "skipped": already,
+        }
+
+    def watch(
+        self,
+        project_dir: str,
+        interval: float = 5.0,
+        max_iterations: Optional[int] = None,
+    ) -> Dict:
+        """Poll a project directory and incrementally upload sessions.
+
+        For environments without a Claude Code hook. Every ``interval`` seconds
+        it scans ``project_dir`` for ``*.jsonl`` sessions and uploads any new
+        turns via :meth:`upload_session_incremental`. Runs until interrupted
+        (or ``max_iterations`` is reached, used by tests).
+
+        Args:
+            project_dir: Claude Code project directory to watch.
+            interval: Seconds between scans.
+            max_iterations: Stop after this many scans (``None`` = forever).
+
+        Returns:
+            Aggregate counts across the watch run.
+        """
+        path = Path(project_dir).expanduser()
+        if not path.is_dir():
+            raise NotADirectoryError(f"Not a directory: {path}")
+
+        total_inserted = 0
+        iterations = 0
+        try:
+            while max_iterations is None or iterations < max_iterations:
+                for jsonl_file in sorted(path.glob("*.jsonl")):
+                    try:
+                        result = self.upload_session_incremental(str(jsonl_file))
+                        total_inserted += result.get("total_inserted", 0)
+                    except Exception:  # noqa: BLE001 - keep watching on errors
+                        logger.exception("watch: failed on %s", jsonl_file.name)
+                iterations += 1
+                if max_iterations is not None and iterations >= max_iterations:
+                    break
+                time.sleep(interval)
+        except KeyboardInterrupt:
+            logger.info("watch: stopped by user")
+        return {"total_inserted": total_inserted, "iterations": iterations}
 
     def upload_project(self, project_dir: str) -> Dict:
         """
@@ -409,21 +512,84 @@ class ClaudeCodeTracer:
         return path.replace("/", "-")
 
 
-# Default public base URL for the SessionEnd hook (Vercel proxy → Supabase).
+# Default public base URL for the hook (Vercel proxy → Supabase).
 DEFAULT_HOOK_BASE_URL = "https://api.monkai.com.br/trace/v1"
+
+# Where per-session upload offsets and (default) the token file live.
+DEFAULT_STATE_DIR = Path.home() / ".monkai_trace"
+DEFAULT_TOKEN_FILE = Path.home() / ".monkai_trace_token"
+
+
+def _state_dir() -> Path:
+    return Path(os.environ.get("MONKAI_TRACE_STATE_DIR", str(DEFAULT_STATE_DIR))).expanduser()
+
+
+def _offsets_path() -> Path:
+    return _state_dir() / "offsets.json"
+
+
+def _load_offsets() -> Dict[str, int]:
+    """Load the per-session upload offsets; tolerant of missing/corrupt files."""
+    path = _offsets_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return {k: int(v) for k, v in data.items()} if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError, ValueError, TypeError):
+        logger.warning("Could not read offsets at %s; starting fresh", path)
+        return {}
+
+
+def _save_offset(session_id: str, count: int) -> None:
+    """Persist the uploaded-turn count for a session (best-effort)."""
+    offsets = _load_offsets()
+    offsets[session_id] = count
+    path = _offsets_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(offsets), encoding="utf-8")
+    except OSError:
+        logger.warning("Could not persist offset for %s at %s", session_id, path)
+
+
+def resolve_token() -> Optional[str]:
+    """Resolve the tracer token from the environment or a token file.
+
+    Order: ``MONKAI_TRACE_TOKEN`` env var, then the token file pointed to by
+    ``MONKAI_TRACE_TOKEN_FILE`` (default ``~/.monkai_trace_token``). The file
+    fallback makes the hook robust even when the shell profile that exports the
+    env var is not sourced by the hook runner.
+    """
+    token = os.environ.get("MONKAI_TRACE_TOKEN")
+    if token:
+        return token.strip()
+    token_file = Path(
+        os.environ.get("MONKAI_TRACE_TOKEN_FILE", str(DEFAULT_TOKEN_FILE))
+    ).expanduser()
+    if token_file.exists():
+        try:
+            value = token_file.read_text(encoding="utf-8").strip()
+            if value:
+                return value
+        except OSError:
+            logger.warning("Could not read token file at %s", token_file)
+    return None
 
 
 def run_hook(stdin=None) -> int:
-    """Entrypoint for the Claude Code ``SessionEnd`` hook.
+    """Entrypoint for the Claude Code ``SessionEnd``/``Stop`` hook.
 
     Reads the hook payload as JSON from stdin (Claude Code provides
-    ``{session_id, transcript_path, cwd, reason, ...}``), then parses and
-    uploads the full session transcript to MonkAI Trace.
+    ``{session_id, transcript_path, cwd, reason, ...}``), then uploads only the
+    turns not uploaded before (incremental), so the same growing transcript can
+    fire on every ``Stop`` without duplicating, and resumed ``SessionEnd`` is
+    safe too.
 
-    Configuration is resolved from environment variables so the hook can be
-    invoked with zero arguments:
+    Configuration is resolved with zero arguments:
 
-    - ``MONKAI_TRACE_TOKEN`` (required): tracer token (``tk_...``).
+    - token: ``MONKAI_TRACE_TOKEN`` env, else ``MONKAI_TRACE_TOKEN_FILE``
+      (default ``~/.monkai_trace_token``). See :func:`resolve_token`.
     - ``MONKAI_TRACE_NAMESPACE`` (optional, default ``claude-code``).
     - ``MONKAI_TRACE_BASE_URL`` (optional, default the public proxy).
 
@@ -445,9 +611,12 @@ def run_hook(stdin=None) -> int:
         logger.info("Hook payload has no transcript_path; nothing to upload")
         return 0
 
-    token = os.environ.get("MONKAI_TRACE_TOKEN")
+    token = resolve_token()
     if not token:
-        logger.warning("MONKAI_TRACE_TOKEN not set; skipping Claude Code trace upload")
+        logger.warning(
+            "No tracer token (MONKAI_TRACE_TOKEN env or token file); "
+            "skipping Claude Code trace upload"
+        )
         return 0
 
     try:
@@ -456,9 +625,9 @@ def run_hook(stdin=None) -> int:
             namespace=os.environ.get("MONKAI_TRACE_NAMESPACE", "claude-code"),
             base_url=os.environ.get("MONKAI_TRACE_BASE_URL", DEFAULT_HOOK_BASE_URL),
         )
-        result = tracer.upload_session(transcript)
+        result = tracer.upload_session_incremental(transcript)
         logger.info(
-            "Claude Code session uploaded: %s records inserted",
+            "Claude Code trace: %s new turns uploaded",
             result.get("total_inserted", 0),
         )
     except Exception:  # noqa: BLE001 - hook must never crash the session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.6.1"
+version = "0.7.0"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -1,5 +1,6 @@
-"""Tests for the Claude Code integration: transcript parsing, the SessionEnd
-hook entrypoint, and settings.json hook install/uninstall."""
+"""Tests for the Claude Code integration: transcript parsing, incremental
+upload + offsets, token resolution, the hook entrypoint, watch, and the
+settings.json hook install/uninstall."""
 
 import json
 from pathlib import Path
@@ -9,12 +10,30 @@ import pytest
 
 from monkai_trace import cli
 from monkai_trace.client import MonkAIClient
-from monkai_trace.integrations.claude_code import ClaudeCodeTracer, run_hook
+from monkai_trace.integrations.claude_code import (
+    ClaudeCodeTracer,
+    resolve_token,
+    run_hook,
+)
 
 
 def _write_jsonl(path: Path, lines: list) -> Path:
     path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
     return path
+
+
+def _turn(user: str, text: str) -> list:
+    return [
+        {"type": "user", "message": {"content": user}},
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4",
+                "content": [{"type": "text", "text": text}],
+                "usage": {"input_tokens": 5, "output_tokens": 4},
+            },
+        },
+    ]
 
 
 SAMPLE_SESSION = [
@@ -32,6 +51,36 @@ SAMPLE_SESSION = [
     },
 ]
 
+TWO_TURNS = _turn("first question", "first answer") + _turn("second question", "second answer")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path, monkeypatch):
+    """Keep offsets and token resolution off the real home dir."""
+    monkeypatch.setenv("MONKAI_TRACE_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN_FILE", str(tmp_path / "no_token_file"))
+    monkeypatch.delenv("MONKAI_TRACE_TOKEN", raising=False)
+    yield
+
+
+def _mock_client(monkeypatch, inserted=1):
+    mock = Mock(spec=MonkAIClient)
+    mock.upload_records_batch.return_value = {
+        "total_inserted": inserted,
+        "total_records": inserted,
+        "failures": [],
+    }
+    monkeypatch.setattr("monkai_trace.integrations.claude_code.MonkAIClient", lambda *a, **k: mock)
+    return mock
+
+
+class _StdIn:
+    def __init__(self, text):
+        self._text = text
+
+    def read(self):
+        return self._text
+
 
 # --- parsing ---------------------------------------------------------------
 
@@ -46,8 +95,7 @@ def test_parse_session_builds_records(tmp_path):
     rec = records[0]
     assert rec.session_id == "abc123"
     assert rec.namespace == "claude-code"
-    roles = [m.role for m in rec.msg]
-    assert roles == ["user", "assistant", "tool"]
+    assert [m.role for m in rec.msg] == ["user", "assistant", "tool"]
     assert rec.input_tokens == 12
     assert rec.output_tokens == 8
 
@@ -58,47 +106,103 @@ def test_parse_session_empty_file(tmp_path):
     assert tracer._parse_session(empty) == []
 
 
+# --- token resolution ------------------------------------------------------
+
+
+def test_resolve_token_env_wins(monkeypatch):
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN", "tk_env")
+    assert resolve_token() == "tk_env"
+
+
+def test_resolve_token_from_file(tmp_path, monkeypatch):
+    tok = tmp_path / "tok"
+    tok.write_text("tk_file\n", encoding="utf-8")
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN_FILE", str(tok))
+    assert resolve_token() == "tk_file"
+
+
+def test_resolve_token_none_when_no_env_no_file():
+    assert resolve_token() is None
+
+
+# --- incremental upload + offsets ------------------------------------------
+
+
+def test_upload_session_incremental_skips_already_uploaded(tmp_path, monkeypatch):
+    session = _write_jsonl(tmp_path / "s.jsonl", TWO_TURNS)
+    mock = _mock_client(monkeypatch, inserted=2)
+    tracer = ClaudeCodeTracer(tracer_token="tk", namespace="claude-code")
+
+    first = tracer.upload_session_incremental(str(session))
+    assert first["total_inserted"] == 2
+    assert first["skipped"] == 0
+
+    second = tracer.upload_session_incremental(str(session))
+    assert second["total_records"] == 0
+    assert second["skipped"] == 2
+    assert mock.upload_records_batch.call_count == 1  # no re-upload
+
+
+def test_upload_session_incremental_uploads_only_new_turn(tmp_path, monkeypatch):
+    session = tmp_path / "grow.jsonl"
+    _write_jsonl(session, _turn("q1", "a1"))
+    mock = _mock_client(monkeypatch, inserted=1)
+    tracer = ClaudeCodeTracer(tracer_token="tk", namespace="claude-code")
+
+    tracer.upload_session_incremental(str(session))  # uploads turn 1
+    _write_jsonl(session, TWO_TURNS)  # transcript grew to 2 turns
+    result = tracer.upload_session_incremental(str(session))
+
+    assert result["skipped"] == 1
+    assert result["total_inserted"] == 1  # only the new turn
+    # second call uploaded exactly one new record (the 2nd turn)
+    _, args, _ = mock.upload_records_batch.mock_calls[1]
+    assert len(args[0]) == 1
+
+
 # --- run_hook --------------------------------------------------------------
-
-
-class _StdIn:
-    def __init__(self, text):
-        self._text = text
-
-    def read(self):
-        return self._text
 
 
 def test_run_hook_uploads_session(tmp_path, monkeypatch):
     session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
     monkeypatch.setenv("MONKAI_TRACE_TOKEN", "tk_test")
-
-    mock_client = Mock(spec=MonkAIClient)
-    mock_client.upload_records_batch.return_value = {
-        "total_inserted": 1,
-        "total_records": 1,
-        "failures": [],
-    }
-    monkeypatch.setattr(
-        "monkai_trace.integrations.claude_code.MonkAIClient",
-        lambda *a, **k: mock_client,
-    )
+    mock = _mock_client(monkeypatch)
 
     payload = json.dumps({"transcript_path": str(session), "session_id": "sess"})
     assert run_hook(stdin=_StdIn(payload)) == 0
-    mock_client.upload_records_batch.assert_called_once()
+    mock.upload_records_batch.assert_called_once()
+
+
+def test_run_hook_incremental_second_call_noop(tmp_path, monkeypatch):
+    session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN", "tk_test")
+    mock = _mock_client(monkeypatch)
+
+    payload = json.dumps({"transcript_path": str(session)})
+    run_hook(stdin=_StdIn(payload))
+    run_hook(stdin=_StdIn(payload))  # nothing new to upload
+    assert mock.upload_records_batch.call_count == 1
+
+
+def test_run_hook_token_from_file(tmp_path, monkeypatch):
+    session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
+    tok = tmp_path / "tok"
+    tok.write_text("tk_file", encoding="utf-8")
+    monkeypatch.setenv("MONKAI_TRACE_TOKEN_FILE", str(tok))
+    mock = _mock_client(monkeypatch)
+
+    payload = json.dumps({"transcript_path": str(session)})
+    assert run_hook(stdin=_StdIn(payload)) == 0
+    mock.upload_records_batch.assert_called_once()  # token came from file
 
 
 def test_run_hook_without_token_skips_upload(tmp_path, monkeypatch):
     session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
-    monkeypatch.delenv("MONKAI_TRACE_TOKEN", raising=False)
-
-    # If a tracer were built, this would explode — proving no upload happens.
+    # autouse fixture already removes env + points token file at a missing path
     monkeypatch.setattr(
         "monkai_trace.integrations.claude_code.ClaudeCodeTracer",
         Mock(side_effect=AssertionError("tracer must not be built without token")),
     )
-
     payload = json.dumps({"transcript_path": str(session)})
     assert run_hook(stdin=_StdIn(payload)) == 0
 
@@ -114,14 +218,25 @@ def test_run_hook_invalid_json_does_not_raise():
 def test_run_hook_upload_failure_is_swallowed(tmp_path, monkeypatch):
     session = _write_jsonl(tmp_path / "sess.jsonl", SAMPLE_SESSION)
     monkeypatch.setenv("MONKAI_TRACE_TOKEN", "tk_test")
-    mock_client = Mock(spec=MonkAIClient)
-    mock_client.upload_records_batch.side_effect = RuntimeError("network down")
-    monkeypatch.setattr(
-        "monkai_trace.integrations.claude_code.MonkAIClient",
-        lambda *a, **k: mock_client,
-    )
+    mock = _mock_client(monkeypatch)
+    mock.upload_records_batch.side_effect = RuntimeError("network down")
     payload = json.dumps({"transcript_path": str(session)})
     assert run_hook(stdin=_StdIn(payload)) == 0  # never propagates
+
+
+# --- watch -----------------------------------------------------------------
+
+
+def test_watch_uploads_incrementally_then_stops(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _write_jsonl(proj / "a.jsonl", SAMPLE_SESSION)
+    _mock_client(monkeypatch, inserted=1)
+    tracer = ClaudeCodeTracer(tracer_token="tk", namespace="claude-code")
+
+    result = tracer.watch(str(proj), interval=0, max_iterations=1)
+    assert result["iterations"] == 1
+    assert result["total_inserted"] == 1
 
 
 # --- install/uninstall hook ------------------------------------------------
@@ -134,18 +249,24 @@ def fake_settings(tmp_path, monkeypatch):
     return settings_path
 
 
+def _all_commands(settings_path: Path, event: str = "SessionEnd") -> list:
+    data = json.loads(settings_path.read_text())
+    return [i["command"] for h in data["hooks"][event] for i in h["hooks"]]
+
+
+def test_install_hook_registers_resolvable_command(fake_settings):
+    assert cli.main(["install-hook"]) == 0
+    cmds = _all_commands(fake_settings)
+    # command carries the stable marker and an absolute/`-m` invocation
+    assert any(cli.HOOK_MARKER in c for c in cmds)
+    assert any(("/" in c) or ("-m monkai_trace.cli" in c) for c in cmds)
+
+
 def test_install_hook_is_idempotent(fake_settings):
     assert cli.main(["install-hook"]) == 0
-    assert cli.main(["install-hook"]) == 0  # second time = no-op
-
-    data = json.loads(fake_settings.read_text())
-    session_end = data["hooks"]["SessionEnd"]
-    monkai_entries = [
-        h
-        for h in session_end
-        if any(i.get("command") == cli.HOOK_COMMAND for i in h.get("hooks", []))
-    ]
-    assert len(monkai_entries) == 1
+    assert cli.main(["install-hook"]) == 0  # no-op
+    monkai = [c for c in _all_commands(fake_settings) if cli.HOOK_MARKER in c]
+    assert len(monkai) == 1
 
 
 def test_install_hook_preserves_existing_hooks(fake_settings):
@@ -155,11 +276,21 @@ def test_install_hook_preserves_existing_hooks(fake_settings):
         )
     )
     assert cli.main(["install-hook"]) == 0
+    cmds = _all_commands(fake_settings)
+    assert "other" in cmds
+    assert any(cli.HOOK_MARKER in c for c in cmds)
 
-    session_end = json.loads(fake_settings.read_text())["hooks"]["SessionEnd"]
-    commands = [i["command"] for h in session_end for i in h["hooks"]]
-    assert "other" in commands
-    assert cli.HOOK_COMMAND in commands
+
+def test_install_hook_token_file_is_baked(fake_settings):
+    assert cli.main(["install-hook", "--token-file", "/home/me/.tok"]) == 0
+    cmds = _all_commands(fake_settings)
+    assert any("MONKAI_TRACE_TOKEN_FILE=" in c and "/home/me/.tok" in c for c in cmds)
+
+
+def test_install_hook_custom_event(fake_settings):
+    assert cli.main(["install-hook", "--event", "Stop"]) == 0
+    cmds = _all_commands(fake_settings, event="Stop")
+    assert any(cli.HOOK_MARKER in c for c in cmds)
 
 
 def test_uninstall_hook_removes_only_monkai(fake_settings):


### PR DESCRIPTION
## O que foi feito
Fecha os dois follow-ups do auto-trace, que remodelam as mesmas funcoes (por isso um PR coeso).

### #34 — Upload incremental (Opcao B / realtime)
- `ClaudeCodeTracer.upload_session_incremental()`: sobe **so os turnos novos**, persistindo offset por `session_id` em `~/.monkai_trace/offsets.json` (`MONKAI_TRACE_STATE_DIR` override).
- `run_hook` agora e incremental → habilita hook `Stop` (quase realtime, por turno) **sem duplicar**, e torna `SessionEnd` retomado seguro (resolve a limitacao da Opcao A).
- `ClaudeCodeTracer.watch()` + comando `monkai-trace watch <dir>` pra ambientes sem hook (implementa o que o docstring prometia).

### #36 — install-hook robusto
- Registra **comando absoluto resolvivel** (`shutil.which` / `python -m monkai_trace.cli`) → dispara mesmo que `monkai-trace` nao esteja no PATH do runner de hooks.
- `resolve_token()`: env `MONKAI_TRACE_TOKEN` **ou** arquivo `MONKAI_TRACE_TOKEN_FILE` (default `~/.monkai_trace_token`) → nao depende do profile ser sourceado.
- Novas flags `--token-file` e `--event Stop`; avisa no install se nao houver token resolvivel.
- Deteccao de hook por marcador estavel (`claude-hook`).

Bump 0.7.0 + changelog.

## Como testar
`pytest tests/test_claude_code.py -v` (22 testes: incremental/offset, resolve_token env+file, watch, install-hook abs path + token-file + idempotencia).

## Checklist
- [x] 40 testes verdes nos modulos afetados
- [x] black + ruff limpos
- [x] run_hook nunca levanta excecao (hook nao quebra a sessao)
- [x] Lib agnostica de cliente

Closes #34
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)