### PR TITLE
feat(claude-code): install-hook registers Stop + SessionEnd by default

### DIFF
--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",

--- a/monkai_trace/cli.py
+++ b/monkai_trace/cli.py
@@ -30,7 +30,11 @@ CLAUDE_SETTINGS = Path.home() / ".claude" / "settings.json"
 # Stable marker used to detect a MonkAI Trace hook regardless of how the
 # command path is resolved (bare name, absolute path, or `python -m`).
 HOOK_MARKER = "claude-hook"
-DEFAULT_EVENT = "SessionEnd"
+# Register on both by default: ``Stop`` fires after every assistant turn
+# (near-realtime per-turn uploads) and ``SessionEnd`` is the end-of-session
+# safety net for sessions that end without a final Stop. The per-session
+# incremental offset makes the overlap a no-op (no duplicate turns).
+DEFAULT_EVENTS = ["Stop", "SessionEnd"]
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -51,9 +55,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_install.add_argument(
         "--event",
-        default=DEFAULT_EVENT,
-        help=f"Hook event to register on (default: {DEFAULT_EVENT}). "
-        "Use 'Stop' for near-realtime per-turn uploads.",
+        nargs="+",
+        metavar="EVENT",
+        default=DEFAULT_EVENTS,
+        help="Hook event(s) to register on (default: Stop SessionEnd). "
+        "'Stop' gives near-realtime per-turn uploads; 'SessionEnd' is the "
+        "end-of-session safety net. Pass one or more, e.g. --event Stop.",
     )
     p_install.add_argument(
         "--token-file",
@@ -131,22 +138,29 @@ def _cmd_claude_hook() -> int:
     return run_hook()
 
 
-def _cmd_install_hook(event: str, token_file: Optional[str]) -> int:
+def _cmd_install_hook(events: List[str], token_file: Optional[str]) -> int:
     from .integrations.claude_code import resolve_token
 
     settings = _load_settings(CLAUDE_SETTINGS)
     hooks = settings.setdefault("hooks", {})
-    event_hooks = hooks.setdefault(event, [])
-
-    if _hook_present(event_hooks):
-        print(f"MonkAI Trace hook already registered on {event}.")
-        return 0
-
     command = _resolve_hook_command(token_file)
-    event_hooks.append({"hooks": [{"type": "command", "command": command}]})
-    _save_settings(CLAUDE_SETTINGS, settings)
-    print(f"Registered MonkAI Trace hook on {event} in {CLAUDE_SETTINGS}.")
-    print(f"  command: {command}")
+
+    registered: List[str] = []
+    for event in events:
+        event_hooks = hooks.setdefault(event, [])
+        if _hook_present(event_hooks):
+            print(f"MonkAI Trace hook already registered on {event}.")
+            continue
+        event_hooks.append({"hooks": [{"type": "command", "command": command}]})
+        registered.append(event)
+
+    if registered:
+        _save_settings(CLAUDE_SETTINGS, settings)
+        print(
+            f"Registered MonkAI Trace hook on {', '.join(registered)} "
+            f"in {CLAUDE_SETTINGS}."
+        )
+        print(f"  command: {command}")
 
     # Robustness: warn now if the hook would have no token at fire time.
     if token_file is None and not resolve_token():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.7.0"
+version = "0.8.0"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -287,10 +287,29 @@ def test_install_hook_token_file_is_baked(fake_settings):
     assert any("MONKAI_TRACE_TOKEN_FILE=" in c and "/home/me/.tok" in c for c in cmds)
 
 
+def test_install_hook_default_registers_stop_and_sessionend(fake_settings):
+    # Default now registers BOTH: Stop (per-turn, near-realtime) + SessionEnd
+    # (end-of-session safety net). Incremental offset makes the overlap a no-op.
+    assert cli.main(["install-hook"]) == 0
+    for event in ("Stop", "SessionEnd"):
+        cmds = _all_commands(fake_settings, event=event)
+        assert any(cli.HOOK_MARKER in c for c in cmds), f"missing hook on {event}"
+
+
+def test_install_hook_default_is_idempotent_across_events(fake_settings):
+    assert cli.main(["install-hook"]) == 0
+    assert cli.main(["install-hook"]) == 0  # no-op on both events
+    for event in ("Stop", "SessionEnd"):
+        monkai = [c for c in _all_commands(fake_settings, event=event) if cli.HOOK_MARKER in c]
+        assert len(monkai) == 1, f"duplicate hook on {event}"
+
+
 def test_install_hook_custom_event(fake_settings):
+    # A single --event overrides the dual default — only Stop is registered.
     assert cli.main(["install-hook", "--event", "Stop"]) == 0
     cmds = _all_commands(fake_settings, event="Stop")
     assert any(cli.HOOK_MARKER in c for c in cmds)
+    assert "SessionEnd" not in json.loads(fake_settings.read_text()).get("hooks", {})
 
 
 def test_uninstall_hook_removes_only_monkai(fake_settings):


### PR DESCRIPTION
## O que
`monkai-trace install-hook` passa a registrar **`Stop` + `SessionEnd`** por padrão (antes: só `SessionEnd`).

- **`Stop`** dispara ao fim de **cada turno** do assistente → upload incremental quase em tempo real (o agente no Hub atualiza por turno, não só no fim da sessão).
- **`SessionEnd`** continua como rede de segurança para sessões que terminam sem um `Stop` final.
- O **offset incremental por `session_id`** (`~/.monkai_trace/`) torna a sobreposição um no-op — zero turns duplicados.
- `--event` agora aceita um ou mais eventos (`nargs="+"`) e sobrescreve o default (ex: `--event Stop` registra só Stop).

## Por que
O envio era automático mas só no `SessionEnd` (batch no fim). Com `Stop`, fica "live por turno" sem custo relevante e sem risco de duplicação. Streaming token-a-token não é viável via hooks (disparam em eventos discretos; transcript é por mensagem) — `Stop` é a granularidade real de "live".

## Mudanças
- `cli.py`: `DEFAULT_EVENTS = ["Stop", "SessionEnd"]`; `--event nargs="+"`; `_cmd_install_hook` itera os eventos (idempotente por evento).
- Bump `0.7.0 → 0.8.0`.

## Testes
`tests/test_claude_code.py`: +2 testes (default registra ambos; idempotente nos dois eventos) e `custom_event` reforçado (single `--event` não registra o outro). **24/24 verdes** em `test_claude_code.py`. (Falhas no resto da suíte local são `ImportError` de extras opcionais num venv 3.9 — alheias a este diff; CI roda 3.10/3.12/3.13 com deps.)

## Pós-merge
`publish.yml` publica 0.8.0 no PyPI (trigger: `pyproject.toml` mudou em main). Máquinas já instaladas pegam o per-turn ao re-rodar `monkai-trace install-hook` (ou `pipx upgrade monkai-trace && monkai-trace install-hook`).
