### PR TITLE
feat(auth): Bearer header, sync token validation + token-file hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,15 @@ never break your Claude Code session. Remove it anytime with
 > The transcript is uploaded once, when the session ends (`SessionEnd`). If you
 > resume a session and end it again, it is re-uploaded in full.
 
+> 🔒 **Protect your token file.** When the token is resolved from a file
+> (`MONKAI_TRACE_TOKEN_FILE`, default `~/.monkai_trace_token`) instead of the
+> `MONKAI_TRACE_TOKEN` env var, restrict it so other users on the machine can't
+> read your tracer token — it authenticates all of your trace traffic:
+>
+> ```bash
+> chmod 600 ~/.monkai_trace_token
+> ```
+
 ### Cline Integration
 
 ```python

--- a/monkai_trace/__init__.py
+++ b/monkai_trace/__init__.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     OpenClawTracer = None
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 __all__ = [
     "MonkAIClient",
     "AsyncMonkAIClient",

--- a/monkai_trace/anonymizer/rules_client.py
+++ b/monkai_trace/anonymizer/rules_client.py
@@ -118,7 +118,9 @@ class RulesClient:
         response = requests.get(
             self.endpoint,
             headers={
-                "tracer_token": self._tracer_token,
+                # RFC 6750 bearer auth (legacy ``tracer_token`` still accepted
+                # server-side as a fallback during the deprecation window).
+                "Authorization": f"Bearer {self._tracer_token}",
                 "Content-Type": "application/json",
             },
             timeout=self._timeout,

--- a/monkai_trace/async_client.py
+++ b/monkai_trace/async_client.py
@@ -103,7 +103,10 @@ class AsyncMonkAIClient:
         """Ensure aiohttp session exists"""
         if self._session is None or self._session.closed:
             headers = {
-                "tracer_token": self.tracer_token,
+                # RFC 6750 bearer auth. The server still accepts the legacy
+                # ``tracer_token`` header as a fallback, but new traffic from
+                # the SDK leads the migration to ``Authorization: Bearer``.
+                "Authorization": f"Bearer {self.tracer_token}",
                 "Content-Type": "application/json"
             }
             self._session = aiohttp.ClientSession(

--- a/monkai_trace/client.py
+++ b/monkai_trace/client.py
@@ -152,7 +152,10 @@ class MonkAIClient:
         self.max_retries = max_retries
         self._session = requests.Session()
         self._session.headers.update({
-            "tracer_token": tracer_token,
+            # RFC 6750 bearer auth. The server still accepts the legacy
+            # ``tracer_token`` header as a fallback, but new traffic from the
+            # SDK leads the migration to ``Authorization: Bearer``.
+            "Authorization": f"Bearer {tracer_token}",
             "Content-Type": "application/json"
         })
         self._anonymizer = BaselineAnonymizer()

--- a/monkai_trace/client.py
+++ b/monkai_trace/client.py
@@ -146,6 +146,9 @@ class MonkAIClient:
             rules_client: Optional pre-built ``RulesClient`` (overrides
                 ``rules_url``/``rules_ttl_seconds`` for full control).
         """
+        if not tracer_token or not tracer_token.startswith("tk_"):
+            raise MonkAIValidationError("Invalid tracer_token format. Must start with 'tk_'")
+
         self.tracer_token = tracer_token
         self.base_url = base_url or self.BASE_URL
         self.timeout = timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "monkai-trace"
-version = "0.8.0"
+version = "0.9.0"
 description = "Official Python SDK for MonkAI - Track and analyze your AI agent conversations"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_auth_header.py
+++ b/tests/test_auth_header.py
@@ -1,0 +1,60 @@
+"""Regression tests pinning the wire auth header to RFC 6750 bearer.
+
+The SDK historically sent the legacy ``tracer_token`` header. Issue #40
+migrates every transport (sync client, async client, RulesClient) to
+``Authorization: Bearer <token>`` while the server keeps accepting the legacy
+header as a fallback. These tests lock the outbound header so a regression to
+the legacy form fails loudly, and assert the legacy header is no longer sent.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from monkai_trace import AsyncMonkAIClient, MonkAIClient
+from monkai_trace.anonymizer.rules_client import RulesClient
+
+
+def test_sync_client_sends_bearer_header():
+    client = MonkAIClient(tracer_token="tk_abc123")
+    headers = client._session.headers
+    assert headers["Authorization"] == "Bearer tk_abc123"
+    # Legacy header must no longer be emitted by the SDK.
+    assert "tracer_token" not in headers
+
+
+def test_async_client_sends_bearer_header():
+    captured = {}
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            captured["headers"] = kwargs.get("headers")
+            self.closed = False
+
+    async def _run():
+        with patch("aiohttp.ClientSession", _FakeSession):
+            client = AsyncMonkAIClient(tracer_token="tk_xyz789")
+            await client._ensure_session()
+
+    asyncio.run(_run())
+
+    assert captured["headers"]["Authorization"] == "Bearer tk_xyz789"
+    assert "tracer_token" not in captured["headers"]
+
+
+def test_rules_client_sends_bearer_header():
+    rc = RulesClient(tracer_token="tk_rules", hub_url="http://hub", ttl_seconds=300)
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["headers"] = headers
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"version": 1, "rules": {"toggles": {}, "custom": []}}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    with patch("monkai_trace.anonymizer.rules_client.requests.get", side_effect=fake_get):
+        rc.get()
+
+    assert captured["headers"]["Authorization"] == "Bearer tk_rules"
+    assert "tracer_token" not in captured["headers"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,18 @@ def test_client_initialization():
     assert client.base_url == MonkAIClient.BASE_URL
 
 
+def test_client_rejects_token_without_tk_prefix():
+    """Sync client validates the tk_ prefix like the async client (issue #41)."""
+    with pytest.raises(MonkAIValidationError):
+        MonkAIClient(tracer_token="not_a_valid_token")
+
+
+def test_client_rejects_empty_token():
+    """Empty token is rejected at construction, not on first request."""
+    with pytest.raises(MonkAIValidationError):
+        MonkAIClient(tracer_token="")
+
+
 def test_client_custom_base_url():
     """Test client with custom base URL"""
     client = MonkAIClient(


### PR DESCRIPTION
Three related auth hardening fixes bundled on one branch (all small, same area).

## O que foi feito

### 1. `Authorization: Bearer` em todos os transportes (#40)
Migra os 3 transportes do SDK de `tracer_token` (legacy) para `Authorization: Bearer <token>` (RFC 6750):
- `MonkAIClient` (sync) — `client.py`
- `AsyncMonkAIClient` — `async_client.py`
- `RulesClient` (fetch de anonymization-rules) — `anonymizer/rules_client.py`

O kwarg `tracer_token=` permanece — só muda o header na rede. Backward-compatible: o servidor ainda aceita o legacy.

### 2. Validação de prefixo `tk_` no sync client (#41)
O `MonkAIClient` (sync) não validava o token, enquanto o `AsyncMonkAIClient` já levantava `MonkAIValidationError` para prefixo ausente. Token malformado só falhava como 401 no 1º request. Espelha a validação async no `__init__` do sync.

### 3. Recomendação `chmod 600` no token file (#42)
Nota de segurança no README junto às instruções de `install-hook`: quando o token vem de `MONKAI_TRACE_TOKEN_FILE` (default `~/.monkai_trace_token`), o arquivo não deve ser legível por outros usuários (autentica todo o tráfego de trace). Docs-only — o warning opcional no install-hook foi deixado fora (marcado como opcional na issue) para manter o escopo do label `documentation`.

## Por que
- **#40**: o contrato (`docs/http_rest_api.md`) recomenda Bearer; legacy é fallback só server-side. O SDK é o consumidor canônico e deve liderar a migração.
- **#41**: consistência de DX sync/async — falhar cedo com erro claro em vez de 401 tardio.
- **#42**: hardening — credencial única não deve ficar world-readable em disco.

## Como testar
1. `pytest tests/test_auth_header.py -v` → sync/async/rules enviam Bearer; legacy não é mais emitido.
2. `pytest tests/test_client.py -v` → sync rejeita token sem `tk_` e token vazio na construção.
3. `pytest tests/` → sem regressões vs. baseline da main.

## Testes e Workflows revisados
- **Novos**: `tests/test_auth_header.py` (3) + 2 casos em `tests/test_client.py`.
- **`test_claude_code.py`** usa `tracer_token="tk"`, mas `_mock_client` faz patch de `MonkAIClient` antes do construtor real → validação não é atingida. Verificado: passa.
- **#42 é docs-only** — nenhum teste/workflow referencia o README; nada a atualizar.
- **Suite completa**: 31 failed + 24 errors são **pré-existentes na main** (deps opcionais não instaladas) — `comm -23` feat vs main: **zero falhas novas**.
- **CHANGELOG.md** não tocado: está parado em 0.5.0 (sem 0.6/0.7/0.8); notas recentes vivem no README por versão lançada e o bump fica para o release.
- **CI** (`ci.yml`): black/ruff são `continue-on-error` (advisory). Drift de black pré-existente e repo-wide não reformatado aqui (style PR separado).

## Checklist
- [x] Testes passando (novos + sem regressão)
- [x] Backward-compatible (#40)
- [x] Falha cedo e clara (#41)
- [x] Guidance de segurança documentada (#42)

Closes #40
Closes #41
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)